### PR TITLE
Add support for reading PDF from byte data

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 | onPageError        |   ✅    | ❌  |      `null`       |
 | gestureRecognizers |   ✅    | ✅  |      `null`       |
 | filePath           |   ✅    | ✅  |                   |
+| pdfData            |   ✅    | ✅  |                   |
 | fitPolicy          |   ✅    | ❌  | `FitPolicy.WIDTH` |
 | enableSwipe        |   ✅    | ✅  |      `true`       |
 | swipeHorizontal    |   ✅    | ✅  |      `false`      |

--- a/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
+++ b/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
@@ -111,7 +111,7 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
                 setPage(methodCall, result);
                 break;
             case "updateSettings":
-                setPage(methodCall, result);
+                updateSettings(methodCall, result);
                 break;
             default:
                 result.notImplemented();

--- a/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
+++ b/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.github.barteksc.pdfviewer.PDFView;
+import com.github.barteksc.pdfviewer.PDFView.Configurator;
 import com.github.barteksc.pdfviewer.listener.*;
 import com.github.barteksc.pdfviewer.util.Constants;
 import com.github.barteksc.pdfviewer.util.FitPolicy;
@@ -29,12 +30,20 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
         methodChannel = new MethodChannel(messenger, "plugins.endigo.io/pdfview_" + id);
         methodChannel.setMethodCallHandler(this);
 
-        if (params.containsKey("filePath")) {
-            String filePath = (String) params.get("filePath");
+        Constants.PRELOAD_OFFSET = 3;
 
-            Constants.PRELOAD_OFFSET = 3;
+        Configurator config = null;
+        if (params.get("filePath") != null) {
+          String filePath = (String) params.get("filePath");
+          config = pdfView.fromUri(getURI(filePath));
+        }
+        else if (params.get("pdfData") != null) {
+          byte[] data = (byte[]) params.get("pdfData");
+          config = pdfView.fromBytes(data);
+        }
 
-            pdfView.fromUri(getURI(filePath))
+        if (config != null) {
+            config
                 .enableSwipe(getBoolean(params, "enableSwipe"))
                 .swipeHorizontal(getBoolean(params, "swipeHorizontal"))
                 .password(getString(params,"password"))

--- a/lib/flutter_pdfview.dart
+++ b/lib/flutter_pdfview.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -16,7 +17,8 @@ enum FitPolicy { WIDTH, HEIGHT, BOTH }
 class PDFView extends StatefulWidget {
   const PDFView({
     Key key,
-    @required this.filePath,
+    this.filePath,
+    this.pdfData,
     this.onViewCreated,
     this.onRender,
     this.onPageChanged,
@@ -33,7 +35,8 @@ class PDFView extends StatefulWidget {
     this.fitEachPage = true,
     this.defaultPage = 0,
     this.fitPolicy = FitPolicy.WIDTH,
-  }) : super(key: key);
+  }) : assert(filePath != null || pdfData != null),
+       super(key: key);
 
   @override
   _PDFViewState createState() => _PDFViewState();
@@ -58,6 +61,7 @@ class PDFView extends StatefulWidget {
 
   /// The initial URL to load.
   final String filePath;
+  final Uint8List pdfData;
 
   final bool enableSwipe;
   final bool swipeHorizontal;
@@ -94,7 +98,7 @@ class _PDFViewState extends State<PDFView> {
       );
     }
     return Text(
-        '$defaultTargetPlatform is not yet supported by the webview_flutter plugin');
+        '$defaultTargetPlatform is not supported');
   }
 
   void _onPlatformViewCreated(int id) {
@@ -116,23 +120,27 @@ class _PDFViewState extends State<PDFView> {
 class _CreationParams {
   _CreationParams({
     this.filePath,
+    this.pdfData,
     this.settings,
   });
 
   static _CreationParams fromWidget(PDFView widget) {
     return _CreationParams(
       filePath: widget.filePath,
+      pdfData: widget.pdfData,
       settings: _PDFViewSettings.fromWidget(widget),
     );
   }
 
   final String filePath;
+  final Uint8List pdfData;
 
   final _PDFViewSettings settings;
 
   Map<String, dynamic> toMap() {
     Map<String, dynamic> params = {
       'filePath': filePath,
+      'pdfData': pdfData,
     };
 
     params.addAll(settings.toMap());


### PR DESCRIPTION
You can provide the actual byte data instead of the filename when you create the PDFView. This made it necessary to remove the `@required` attribute but an extra assert checks if either a path or the data is provided.

There is one small unrelated change, an error message still referred to the original webview plugin you got the boilerplate from. :-)