### PR TITLE
IOS unlimited zoom-out

### DIFF
--- a/ios/Classes/FlutterPDFView.m
+++ b/ios/Classes/FlutterPDFView.m
@@ -82,9 +82,9 @@
                 }
 
                 [_pdfView usePageViewController:pageFling withViewOptions:nil];
-                _pdfView.autoScales = autoSpacing;
                 _pdfView.displayMode = enableSwipe ? kPDFDisplaySinglePageContinuous : kPDFDisplaySinglePage;
                 _pdfView.document = document;
+                _pdfView.autoScales = autoSpacing;
 
                 NSUInteger pageCount = [document pageCount];
             
@@ -114,7 +114,7 @@
 
                 _pdfView.scaleFactor = scale;
 
-                _pdfView.minScaleFactor = _pdfView.scaleFactorForSizeToFit;
+                _pdfView.minScaleFactor = scale;
                 _pdfView.maxScaleFactor = 4.0;
 
                 dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
on IOS i had the issue that i could keep on zooming out. On Android we don't have this issue, it always scales automatically to fill the page again.

I looked this up and came across this:
https://stackoverflow.com/questions/47270798/pdfview-pinch-zooming-out

But i saw this was already implemented. While debugging i saw that you set the scale manually, and this actually always resets the 'autoScales' property to false. But removing this setting of the scale didn't solve the issue. So i used the calculated scale for the minScaleFactor and this fixes it. Now we have the same behaviour on IOS as on Android.

<img width="405" alt="Screenshot 2020-06-15 at 15 58 34" src="https://user-images.githubusercontent.com/71901/84666654-a7aaed80-af21-11ea-80cd-c5e3948094fb.png">
<img width="399" alt="Screenshot 2020-06-15 at 16 00 32" src="https://user-images.githubusercontent.com/71901/84666645-a4176680-af21-11ea-9ffe-1f437f0a33d1.png">
