### PR TITLE
iOS proper scaling for PDF with pages on landscape-orientation

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   String pathPDF = "";
+  String landscapePathPdf = "";
   String remotePDFpath = "";
   String corruptedPathPDF = "";
 
@@ -30,6 +31,11 @@ class _MyAppState extends State<MyApp> {
     fromAsset('assets/demo-link.pdf', 'demo.pdf').then((f) {
       setState(() {
         pathPDF = f.path;
+      });
+    });
+    fromAsset('assets/demo-landscape.pdf', 'landscape.pdf').then((f) {
+      setState(() {
+        landscapePathPdf = f.path;
       });
     });
 
@@ -102,6 +108,19 @@ class _MyAppState extends State<MyApp> {
                         context,
                         MaterialPageRoute(
                           builder: (context) => PDFScreen(path: pathPDF),
+                        ),
+                      );
+                    }
+                  },
+                ),
+                RaisedButton(
+                  child: Text("Open Landscape PDF"),
+                  onPressed: () {
+                    if (landscapePathPdf != null || landscapePathPdf.isNotEmpty) {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => PDFScreen(path: landscapePathPdf),
                         ),
                       );
                     }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -37,6 +37,7 @@ flutter:
     - assets/demo.pdf
     - assets/corrupted.pdf
     - assets/demo-link.pdf
+    - assets/demo-landscape.pdf
   #  - images/a_dot_burr.jpeg
   #  - images/a_dot_ham.jpeg
   # An image asset can refer to one or more resolution-specific "variants", see

--- a/ios/Classes/FlutterPDFView.m
+++ b/ios/Classes/FlutterPDFView.m
@@ -50,7 +50,7 @@
         NSString* channelName = [NSString stringWithFormat:@"plugins.endigo.io/pdfview_%lld", viewId];
         _channel = [FlutterMethodChannel methodChannelWithName:channelName binaryMessenger:messenger];
         
-        _pdfView = [[PDFView alloc] initWithFrame:frame];
+        _pdfView = [[PDFView alloc] initWithFrame: [[UIScreen mainScreen] bounds]];
         __weak __typeof__(self) weakSelf = self;
         _pdfView.delegate = self;
         
@@ -64,8 +64,6 @@
         BOOL enableSwipe = [args[@"enableSwipe"] boolValue];
         _preventLinkNavigation = [args[@"preventLinkNavigation"] boolValue];
         
-        NSInteger defaultPage = [args[@"defaultPage"] integerValue];
-
         NSString* filePath = args[@"filePath"];
 
         if ([filePath isKindOfClass:[NSString class]]) {
@@ -96,35 +94,7 @@
                     [_pdfView.document unlockWithPassword:password];
                 }
 
-                NSUInteger pageCount = [document pageCount];
-            
-                if (pageCount <= defaultPage) {
-                    defaultPage = pageCount - 1;
-                }
-
-                PDFPage* page = [document pageAtIndex: defaultPage];
-                [_pdfView goToPage: page];
-
-                CGRect pageRect = [page boundsForBox:[_pdfView displayBox]];
-
-                CGRect parentRect = [[UIScreen mainScreen] bounds];
-
-                if (frame.size.width > 0 && frame.size.height > 0) {
-                    parentRect = frame;
-                }
-
-                CGFloat scale = 1.0f;
-                if (parentRect.size.width / parentRect.size.height >= pageRect.size.width / pageRect.size.height) {
-                    scale = parentRect.size.height / pageRect.size.height;
-                } else {
-                    scale = parentRect.size.width / pageRect.size.width;
-                }
-
-                NSLog(@"scale %f", scale);
-
-                _pdfView.scaleFactor = scale;
-
-                _pdfView.minScaleFactor = scale;
+                _pdfView.minScaleFactor = _pdfView.scaleFactorForSizeToFit;
                 _pdfView.maxScaleFactor = 4.0;
 
                 dispatch_async(dispatch_get_main_queue(), ^{

--- a/ios/Classes/FlutterPDFView.m
+++ b/ios/Classes/FlutterPDFView.m
@@ -64,6 +64,8 @@
         BOOL enableSwipe = [args[@"enableSwipe"] boolValue];
         _preventLinkNavigation = [args[@"preventLinkNavigation"] boolValue];
         
+        NSInteger defaultPage = [args[@"defaultPage"] integerValue];
+
         NSString* filePath = args[@"filePath"];
 
         if ([filePath isKindOfClass:[NSString class]]) {
@@ -93,6 +95,15 @@
                 if ([password isKindOfClass:[NSString class]] && [_pdfView.document isEncrypted]) {
                     [_pdfView.document unlockWithPassword:password];
                 }
+
+                NSUInteger pageCount = [document pageCount];
+
+                if (pageCount <= defaultPage) {
+                    defaultPage = pageCount - 1;
+                }
+
+                PDFPage* page = [document pageAtIndex: defaultPage];
+                [_pdfView goToPage: page];
 
                 _pdfView.minScaleFactor = _pdfView.scaleFactorForSizeToFit;
                 _pdfView.maxScaleFactor = 4.0;


### PR DESCRIPTION
When a PDF that have pages on landscape orientation is opened and rendered the first time, a scaling issue is visible and the result render shows the PDF page clipped on the sides rather than auto-scaling to fit the available width.

The solution was to initialize the `PDFView` using the `mainScreen` bounds as frame, thus allowing the view to automatically calculate the `scaleFactorForSizeToFit` value. Then this value is used as the minimum scale factor.

### Before
![image](https://user-images.githubusercontent.com/15662383/93691076-f5497000-faa5-11ea-9386-ae4d6135d7fc.png)

### After
![image](https://user-images.githubusercontent.com/15662383/93691079-fbd7e780-faa5-11ea-9d3a-b2a8c3f43c5f.png)
