### PR TITLE
Fixed setPage return value from int to bool on iOS

### DIFF
--- a/ios/Classes/FlutterPDFView.m
+++ b/ios/Classes/FlutterPDFView.m
@@ -169,7 +169,7 @@
     NSNumber* page = arguments[@"page"];
     
     [_pdfView goToPage: [_pdfView.document pageAtIndex: page.unsignedLongValue ]];
-    result(_currentPage);
+    result(true);
 }
 
 - (void)onUpdateSettings:(FlutterMethodCall*)call result:(FlutterResult)result {


### PR DESCRIPTION
Hi, I realized that `setPage` method returns wrong type on iOS.
As you can see below, Android and iOS returns different value and flutter receives as type `bool`.

```
// Android
    void setPage(MethodCall call, Result result) {
        if (call.argument("page") != null) {
            int page = (int) call.argument("page");
            pdfView.jumpTo(page);
        }

        result.success(true); // <- Returns value as type `bool`
    }
```

```
// iOS
- (void)setPage:(FlutterMethodCall*)call result:(FlutterResult)result {
    NSDictionary<NSString*, NSNumber*>* arguments = [call arguments];
    NSNumber* page = arguments[@"page"];
    
    [_pdfView goToPage: [_pdfView.document pageAtIndex: page.unsignedLongValue ]];
    result(_currentPage); // <- Returns valus as `int`
}
```

```
// Flutter

  Future<bool> setPage(int page) async {
    final bool isSet = await _channel.invokeMethod('setPage', <String, dynamic>{
      'page': page,
    });
    return isSet;
  }
```

then, we crash on iOS when calling `setPage`

```
Exception has occurred.
_CastError (type 'int' is not a subtype of type 'bool' in type cast)
```

