### PR TITLE
Migration Android V2 Embedding & jCenter to mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,6 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
     }
 }
 

--- a/android/src/main/java/io/endigo/plugins/pdfviewflutter/PDFViewFlutterPlugin.java
+++ b/android/src/main/java/io/endigo/plugins/pdfviewflutter/PDFViewFlutterPlugin.java
@@ -1,13 +1,22 @@
 package io.endigo.plugins.pdfviewflutter;
 
-import io.flutter.plugin.common.PluginRegistry.Registrar;
+import androidx.annotation.NonNull;
 
-public class PDFViewFlutterPlugin {
-    /** Plugin registration. */
-    public static void registerWith(Registrar registrar) {
-        registrar
-                .platformViewRegistry()
-                .registerViewFactory(
-                        "plugins.endigo.io/pdfview", new PDFViewFactory(registrar.messenger()));
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.BinaryMessenger;
+
+public class PDFViewFlutterPlugin implements FlutterPlugin {
+    /**
+     * Plugin registration.
+     */
+    @Override
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+        binding
+                .getPlatformViewRegistry()
+                .registerViewFactory("plugins.endigo.io/pdfview", new PDFViewFactory(binding.getBinaryMessenger()));
+    }
+
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     }
 }


### PR DESCRIPTION
As mention in #146, in future version of flutter this plugin won't work. I've migrated PDFViewFlutterPlugin and jCenter to mavenCentral as mentioned here https://developer.android.com/studio/build/jcenter-migration.

Potential fixes of:

- #146 
- #141 