### PR TITLE
Updating plugin configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add this to your package's pubspec.yaml file:
 
 ```
 dependencies:
-  flutter_pdfview: ^1.0.4
+  flutter_pdfview: ^1.2.0
 ```
 
 ### 2. Install it
@@ -30,22 +30,7 @@ $ flutter packages get
 
 Alternatively, your editor might support pub get or `flutter packages get`. Check the docs for your editor to learn more.
 
-### 3. Setup
-
-#### iOS
-
-Opt-in to the embedded views preview by adding a boolean property to the app's `Info.plist` file
-with the key `io.flutter.embedded_views_preview` and the value `YES`.
-
-```
-# Info.plist
-...
-<key>io.flutter.embedded_views_preview</key>
-<true/>
-...
-```
-
-### 4. Import it
+### 3. Import it
 
 Now in your Dart code, you can use:
 
@@ -114,14 +99,6 @@ PDFView(
     print('page change: $page/$total');
   },
 ),
-```
-
-# For production usage
-
-If you use proguard, you should include this line.
-
-```
--keep class com.shockwave.**
 ```
 
 # Dependencies

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.barteksc:android-pdf-viewer:3.1.0-beta.1'
+    implementation 'com.github.barteksc:android-pdf-viewer:3.2.0-beta.1'
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.2"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -115,21 +115,21 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.2"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -143,28 +143,28 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.3"
   platform:
     dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   process:
     dependency: transitive
     description:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -176,7 +176,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -211,7 +211,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
@@ -232,7 +232,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.6"
   xdg_directories:
     dependency: transitive
     description:
@@ -241,5 +241,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  dart: ">=2.13.0 <3.0.0"
+  flutter: ">=2.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.1.0
 homepage: https://github.com/endigo/flutter_pdfview
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  sdk: ">=2.12.0 < 3.0.0"
+  flutter: ">=2.2.0 < 3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR contains no breaking change.

1. Updated dependencies to be newest with latest flutter version.
2. Allowed myself to update minimal flutter version to 2.2.0 since this package is already null safety no need to go below 2.0.0 version. Updated to 2.2.0 because has optimization improvment.
3. Updated compileSdkVersion in Android gradle to 30 because in future new apps on Google Play will have to set at least compile version to 30.
4. Updated README: 

- Removed third step for setup to ios. Since minimal version will be now 2.2.0 no needs to implement ('io.flutter.embedded_views_preview') because of flutter version 1.22 and above its not needed any more.
```
<key>io.flutter.embedded_views_preview</key>
<true/>
```

- Removed 'For production usage' step since ProGuard with '-keep class com.shockwave.**' is already implemented inside plugin  #87 .

5. Updated Native Android dependency of AndroidPdfViewer to 3.2.0-beta.1 because of fixes that update include. 