### PR TITLE
Change dependency for AndroidPdfViewer

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.barteksc:android-pdf-viewer:3.2.0-beta.1'
+    implementation 'com.github.mhiew:android-pdf-viewer:3.2.0-beta.1'
 }
 


### PR DESCRIPTION
The original repository at com.github.barteksc is no longer available in the google() and mavenCentral() repositories. It now lives  at com.github.mhiew, where it is actively maintained