### PR TITLE
fix(android): build.gradle namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ android {
         disable 'InvalidPackage'
     }
 
-    if (project.android.hasProperty("namespace")) { namespace 'io.endigo.plugings.pdfview' }
+    if (project.android.hasProperty("namespace")) { namespace 'io.endigo.plugins.pdfviewflutter' }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,8 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    if (project.android.hasProperty("namespace")) { namespace 'io.endigo.plugings.pdfview' }
 }
 
 dependencies {


### PR DESCRIPTION
Make it conditional, because it could break the build on Gradle < 8.0