### PR TITLE
feat: add maxZoom support for iOS and Android

### DIFF
--- a/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
+++ b/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
@@ -57,6 +57,9 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
         Object maxZoom = params.get("maxZoom");
         if (maxZoom != null) {
             float max = ((Number) maxZoom).floatValue();
+            // NOTE: Android's PDFView zoom scaling is about half of iOS PDFKit.
+            // Multiply by 2 to normalize so that a Dart value like maxZoom = 3.0
+            // results in ~300% zoom on both iOS and Android.
             pdfView.setMaxZoom(max * 2);
         }
 

--- a/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
+++ b/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
@@ -54,6 +54,12 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
             pdfView.setBackgroundColor(color);
         }
 
+        Object maxZoom = params.get("maxZoom");
+        if (maxZoom != null) {
+            float max = ((Number) maxZoom).floatValue();
+            pdfView.setMaxZoom(max * 2);
+        }
+
         if (config != null) {
             config
                     .enableSwipe(getBoolean(params, "enableSwipe"))

--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.m
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.m
@@ -165,7 +165,11 @@
         }
         _pdfView.document = document;
 
-        _pdfView.maxScaleFactor = [args[@"maxZoom"] doubleValue];
+        NSNumber *maxZoom = args[@"maxZoom"];
+        if (maxZoom != nil && [maxZoom isKindOfClass:[NSNumber class]]) {
+            _pdfView.maxScaleFactor = [maxZoom doubleValue];
+        }
+
         _pdfView.minScaleFactor = _pdfView.scaleFactorForSizeToFit;
 
         NSString* password = args[@"password"];

--- a/lib/flutter_pdfview.dart
+++ b/lib/flutter_pdfview.dart
@@ -39,7 +39,9 @@ class PDFView extends StatefulWidget {
     this.fitPolicy = FitPolicy.WIDTH,
     this.preventLinkNavigation = false,
     this.backgroundColor,
+    this.maxZoom = 3.0,
   })  : assert(filePath != null || pdfData != null),
+        assert(maxZoom > 1.0, 'maxZoom must be greater than 1.0'),
         super(key: key);
 
   @override
@@ -119,6 +121,9 @@ class PDFView extends StatefulWidget {
 
   /// Use to change the background color. ex : "#FF0000" => red
   final Color? backgroundColor;
+
+  /// Use to change the maximal zoom. Must be greater than 1.0, default 3.0.
+  final double maxZoom;
 }
 
 class _PDFViewState extends State<PDFView> {
@@ -237,6 +242,7 @@ class _PDFViewSettings {
     this.fitPolicy,
     this.preventLinkNavigation,
     this.backgroundColor,
+    this.maxZoom,
   });
 
   static _PDFViewSettings fromWidget(PDFView widget) {
@@ -252,6 +258,7 @@ class _PDFViewSettings {
       fitPolicy: widget.fitPolicy,
       preventLinkNavigation: widget.preventLinkNavigation,
       backgroundColor: widget.backgroundColor,
+      maxZoom: widget.maxZoom,
     );
   }
 
@@ -267,6 +274,7 @@ class _PDFViewSettings {
   final bool? preventLinkNavigation;
 
   final Color? backgroundColor;
+  final double? maxZoom;
 
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
@@ -281,6 +289,7 @@ class _PDFViewSettings {
       'fitPolicy': fitPolicy.toString(),
       'preventLinkNavigation': preventLinkNavigation,
       'backgroundColor': backgroundColor?.value,
+      'maxZoom': maxZoom,
     };
   }
 


### PR DESCRIPTION
## What I did
- Added `maxZoom` parameter to control the maximum zoom level in PDFView
- iOS: implemented using `PDFView.maxScaleFactor` (relative to `scaleFactorForSizeToFit`)
- Android: implemented using `setMaxZoom()`
- Ensured zoom consistency after layout / rotation by clamping scaleFactor

## Why
Currently, flutter_pdfview does not provide a way to limit zoom scale. 
This feature gives developers better control over user experience and performance.

## Related Issues
- #296 
- #276 
- #257 
- #180 
- #152 
- #58 

## Notes
- Default behavior: `maxZoom` = 3.0 (relative to fit scale on iOS)
- Backward compatible: existing apps without `maxZoom` parameter will not break


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional maxZoom option to PDFView (default 3.0) to control maximum zoom across Android and iOS.

* **Bug Fixes**
  * Added validation and safer handling of maxZoom so invalid or missing values no longer cause unstable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->