### PR TITLE
feat:Add spacing parameter to PDF viewer for customizable page spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 | nightMode             |   ✅    | ❌  |      `false`      |
 | password              |   ✅    | ✅  |      `null`       |
 | autoSpacing           |   ✅    | ✅  |      `true`       |
+| spacing               |   ✅    | ✅  |        `0`        |
 | pageFling             |   ✅    | ✅  |      `true`       |
 | pageSnap              |   ✅    | ❌  |      `true`       |
 | preventLinkNavigation |   ✅    | ✅  |      `false`      |

--- a/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
+++ b/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
@@ -71,6 +71,7 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
                     .password(getString(params, "password"))
                     .nightMode(getBoolean(params, "nightMode"))
                     .autoSpacing(getBoolean(params, "autoSpacing"))
+                    .spacing(getInt(params, "spacing"))
                     .pageFling(getBoolean(params, "pageFling"))
                     .pageSnap(getBoolean(params, "pageSnap"))
                     .pageFitPolicy(getFitPolicy(params))

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -219,6 +219,7 @@ class _PDFScreenState extends State<PDFScreen> with WidgetsBindingObserver {
                 : true, // Vertical scrolling is safer on iPad
             autoSpacing:
                 widget.isIPadSafe ? true : false, // Let PDFKit handle spacing
+            spacing: widget.isIPadSafe ? 0 : 10,
             pageFling: widget.isIPadSafe
                 ? false
                 : true, // Disable page fling to avoid conflicts

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
-  path_provider: ^2.0.1
+  cupertino_icons: ^1.0.8
+  path_provider: ^2.1.5
   flutter_pdfview:
     path: ../
 

--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.m
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.m
@@ -101,6 +101,7 @@
     PDFDestination* _currentDestination;
     BOOL _preventLinkNavigation;
     BOOL _autoSpacing;
+    NSInteger _spacing;
     PDFPage* _defaultPage;
     BOOL _defaultPageSet;
     BOOL _isIPad;
@@ -120,6 +121,7 @@
     _pdfView.delegate = self;
 
     _autoSpacing = [args[@"autoSpacing"] boolValue];
+    _spacing = [args[@"spacing"] integerValue];
     BOOL pageFling = [args[@"pageFling"] boolValue];
     BOOL enableSwipe = [args[@"enableSwipe"] boolValue];
     _preventLinkNavigation = [args[@"preventLinkNavigation"] boolValue];
@@ -153,6 +155,10 @@
         }
 
         _pdfView.autoScales = _autoSpacing;
+
+        if (@available(iOS 11.0, *)) {
+            _pdfView.pageBreakMargins = UIEdgeInsetsMake(_spacing, 0, _spacing, 0);
+        }
 
         // On iPad, avoid conflicting display modes with page view controller
         if (_isIPad && pageFling && enableSwipe) {

--- a/lib/flutter_pdfview.dart
+++ b/lib/flutter_pdfview.dart
@@ -32,6 +32,7 @@ class PDFView extends StatefulWidget {
     this.password,
     this.nightMode = false,
     this.autoSpacing = true,
+    this.spacing = 0,
     this.pageFling = true,
     this.pageSnap = true,
     this.enableAntialiasing = true,
@@ -98,6 +99,9 @@ class PDFView extends StatefulWidget {
 
   /// Indicates whether or not the PDF viewer automatically adds spacing between pages. If set to true, spacing is added.
   final bool autoSpacing;
+
+  /// Indicates the amount of spacing between pages in the PDF document.
+  final int spacing;
 
   /// Indicates whether or not the user can "fling" pages in the PDF document. If set to true, page flinging is enabled.
   final bool pageFling;
@@ -247,6 +251,7 @@ class _PDFViewSettings {
     this.password,
     this.nightMode,
     this.autoSpacing,
+    this.spacing,
     this.pageFling,
     this.pageSnap,
     this.enableAntialiasing,
@@ -266,6 +271,7 @@ class _PDFViewSettings {
       password: widget.password,
       nightMode: widget.nightMode,
       autoSpacing: widget.autoSpacing,
+      spacing: widget.spacing,
       pageFling: widget.pageFling,
       pageSnap: widget.pageSnap,
       enableAntialiasing: widget.enableAntialiasing,
@@ -284,6 +290,7 @@ class _PDFViewSettings {
   final String? password;
   final bool? nightMode;
   final bool? autoSpacing;
+  final int? spacing;
   final bool? pageFling;
   final bool? pageSnap;
   final bool? enableAntialiasing;
@@ -303,6 +310,7 @@ class _PDFViewSettings {
       'password': password,
       'nightMode': nightMode,
       'autoSpacing': autoSpacing,
+      'spacing': spacing,
       'pageFling': pageFling,
       'pageSnap': pageSnap,
       'enableAntialiasing': enableAntialiasing,

--- a/test/flutter_pdfview_test.dart
+++ b/test/flutter_pdfview_test.dart
@@ -167,12 +167,14 @@ void main() {
         swipeHorizontal: true,
         pageFling: false,
         pageSnap: false,
+        spacing: 15,
       );
 
       expect(customPdfView.enableSwipe, false);
       expect(customPdfView.swipeHorizontal, true);
       expect(customPdfView.pageFling, false);
       expect(customPdfView.pageSnap, false);
+      expect(customPdfView.spacing, 15);
     });
   });
 


### PR DESCRIPTION
   1 - Add custom spacing option to PDFView
   2 - Added `spacing` parameter to PDFView widget (defaults to 0)
   3 - Implemented `spacing` on Android using `com.github.barteksc.pdfviewer`
   4 - Implemented `spacing` on iOS using PDFKit `pageBreakMargins`
   5 - Updated README and example app to demonstrate the new feature
   6 - Added unit test for spacing parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adjustable page spacing control for PDF viewing, allowing customization of whitespace between pages across platforms.

* **Documentation**
  * Added spacing option documentation to the configuration guide.

* **Chores**
  * Updated project dependencies.

* **Tests**
  * Added test coverage for the new spacing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->