### PR TITLE
Fix: #337 Scroll indicator issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 | backgroundColor       |   ✅    | ✅  |      `null`       |
 | minZoom               |   ✅    | ✅  |        1.0        |
 | maxZoom               |   ✅    | ✅  |        4.0        |
+| showScrollIndicators* |   ✅    | ✅  |      `false`      |
+
+*`showScrollIndicators` is ignored in iOS if `pageFling` is set to true
 
 ## Controller Options
 
@@ -92,6 +95,7 @@ PDFView(
   swipeHorizontal: true,
   autoSpacing: false,
   pageFling: false,
+  showScrollIndicators: true,
   backgroundColor: Colors.grey,
   onRender: (_pages) {
     setState(() {

--- a/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
+++ b/android/src/main/java/io/endigo/plugins/pdfviewflutter/FlutterPDFView.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 import com.github.barteksc.pdfviewer.PDFView;
 import com.github.barteksc.pdfviewer.PDFView.Configurator;
 import com.github.barteksc.pdfviewer.link.LinkHandler;
+import com.github.barteksc.pdfviewer.scroll.DefaultScrollHandle;
 import com.github.barteksc.pdfviewer.util.Constants;
 import com.github.barteksc.pdfviewer.util.FitPolicy;
 import com.shockwave.pdfium.util.SizeF;
@@ -19,6 +20,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
@@ -55,12 +57,10 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
 
         pdfView.useBestQuality(getBoolean(params, "useBestQuality"));
         pdfView.enableRenderDuringScale(getBoolean(params, "enableRenderDuringScale"));
-        Float thumbnailRatio = getFloat(params, "thumbnailRatio");
-
-        if (thumbnailRatio != null) {
-            Constants.THUMBNAIL_RATIO = thumbnailRatio;
+        Object thumbnailRatioObj = params.get("thumbnailRatio");
+        if (thumbnailRatioObj instanceof Number) {
+            Constants.THUMBNAIL_RATIO = ((Number) thumbnailRatioObj).floatValue();
         }
-//        Constants.Cache.THUMBNAILS_CACHE_SIZE = 0;
 
         Configurator config = null;
         if (params.get("filePath") != null) {
@@ -88,6 +88,7 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
                     .pageSnap(getBoolean(params, "pageSnap"))
                     .pageFitPolicy(getFitPolicy(params))
                     .enableAnnotationRendering(true)
+                    .scrollHandle(getBoolean(params, "showScrollIndicators") ? new DefaultScrollHandle(context) : null)
                     .linkHandler(linkHandler)
                     .enableAntialiasing(getBoolean(params, "enableAntialiasing"))
                     .enableDoubletap(true)
@@ -127,10 +128,10 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
                         methodChannel.invokeMethod("onLoadComplete", args);
                     }).load();
 
-            Float maxZoom = getFloat(params, "maxZoom");
-            Float minZoom = getFloat(params, "minZoom");
-            float effectiveMax = maxZoom != null ? maxZoom : DEFAULT_MAX_ZOOM;
-            float effectiveMin = minZoom != null ? minZoom : DEFAULT_MIN_ZOOM;
+            float effectiveMax = getFloat(params, "maxZoom", DEFAULT_MAX_ZOOM);
+            float effectiveMin = getFloat(params, "minZoom", DEFAULT_MIN_ZOOM);
+//            float effectiveMax = maxZoom != null ? maxZoom : DEFAULT_MAX_ZOOM;
+//            float effectiveMin = minZoom != null ? minZoom : DEFAULT_MIN_ZOOM;
             if (effectiveMin > effectiveMax) {
                 effectiveMin = effectiveMax;
             }
@@ -223,18 +224,10 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
     void setPosition(MethodCall call, Result result) {
         Double xPosObj = call.argument("xPos");
         double xOffset;
-        if (xPosObj != null) {
-            xOffset = xPosObj; // Safe unboxing
-        } else {
-            xOffset = 0.0;
-        }
+        xOffset = Objects.requireNonNullElse(xPosObj, 0.0); // Safe unboxing
         Double yPosObj = call.argument("yPos");
         double yOffset;
-        if (yPosObj != null) {
-            yOffset = yPosObj; // Safe unboxing
-        } else {
-            yOffset = 0.0;
-        }
+        yOffset = Objects.requireNonNullElse(yPosObj, 0.0); // Safe unboxing
         pdfView.moveTo((float) xOffset * displayDensity, (float) yOffset * displayDensity);
         pdfView.loadPages();
         result.success(true);
@@ -243,11 +236,7 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
     void setScale(MethodCall call, Result result) {
         Double scaleObj = call.argument("scale");
         double zoom;
-        if (scaleObj != null) {
-            zoom = scaleObj; // Safe unboxing
-        } else {
-            zoom = 1.0;
-        }
+        zoom = Objects.requireNonNullElse(scaleObj, 1.0); // Safe unboxing
 
         if (zoom != 1.0) {
             pdfView.zoomTo((float) zoom);
@@ -332,11 +321,7 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
         if (call.argument("page") != null) {
             Integer pageObj = call.argument("page");
             int page;
-            if (pageObj != null) {
-                page = pageObj; // Safe unboxing
-            } else {
-                page = 1;
-            }
+            page = Objects.requireNonNullElse(pageObj, 1); // Safe unboxing
             pdfView.jumpTo(page);
         }
 
@@ -369,10 +354,10 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
                     plh.setPreventLinkNavigation(getBoolean(settings, key));
                     break;
                 case "maxZoom":
-                    pdfView.setMaxZoom(getFloat(settings, key));
+                    pdfView.setMaxZoom(getFloat(settings, key, DEFAULT_MAX_ZOOM));
                     break;
                 case "minZoom":
-                    pdfView.setMinZoom(getFloat(settings, key));
+                    pdfView.setMinZoom(getFloat(settings, key, DEFAULT_MIN_ZOOM));
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown PDFView setting: " + key);
@@ -391,11 +376,7 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
     private boolean getBoolean(Map<String, Object> params, String key) {
         Boolean keyObj = (Boolean) params.get(key);
         boolean bKey;
-        if (keyObj != null) {
-            bKey = keyObj;
-        } else {
-            bKey = false;
-        }
+        bKey = Objects.requireNonNullElse(keyObj, false);
         return params.containsKey(key) && bKey;
     }
 
@@ -406,36 +387,25 @@ public class FlutterPDFView implements PlatformView, MethodCallHandler {
     private int getInt(Map<String, Object> params, String key) {
         Integer keyObj = (Integer) params.get(key);
         int intKey;
-        if (keyObj != null) {
-            intKey = keyObj;
-        } else {
-            intKey = 0;
-        }
+        intKey = Objects.requireNonNullElse(keyObj, 0);
         return params.containsKey(key) ? intKey : 0;
     }
 
-    private Float getFloat(Map<String, Object> params, String key) {
-        if (!params.containsKey(key)) {
-            return null;
-        }
+    private float getFloat(Map<String, Object> params, String key, float defaultValue) {
         Object value = params.get(key);
         if (value instanceof Number) {
             return ((Number) value).floatValue();
         }
-        return null;
+        return defaultValue;
     }
 
     private FitPolicy getFitPolicy(Map<String, Object> params) {
         String fitPolicy = getString(params, "fitPolicy");
-        switch (fitPolicy) {
-            case "FitPolicy.WIDTH":
-                return FitPolicy.WIDTH;
-            case "FitPolicy.HEIGHT":
-                return FitPolicy.HEIGHT;
-            case "FitPolicy.BOTH":
-            default:
-                return FitPolicy.BOTH;
-        }
+        return switch (fitPolicy) {
+            case "FitPolicy.WIDTH" -> FitPolicy.WIDTH;
+            case "FitPolicy.HEIGHT" -> FitPolicy.HEIGHT;
+            default -> FitPolicy.BOTH;
+        };
     }
 
     private Uri getURI(final String uri) {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1510"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import UIKit
 import Flutter
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+    override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?
+    ) -> Bool {
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+    
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -26,6 +26,27 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -213,13 +213,14 @@ class _PDFScreenState extends State<PDFScreen> with WidgetsBindingObserver {
         children: <Widget>[
           PDFView(
             filePath: widget.path,
+            enableSwipe: true,
             // iPad Safe Mode: Avoid conflicting scroll configurations
-            enableSwipe: widget.isIPadSafe ? true : true,
             swipeHorizontal:
                 widget.isIPadSafe ? false : true, // Vertical scrolling is safer on iPad
             autoSpacing: widget.isIPadSafe ? true : false, // Let PDFKit handle spacing
             pageFling: widget.isIPadSafe ? false : true, // Disable page fling to avoid conflicts
-            pageSnap: widget.isIPadSafe ? false : true, // Disable page snap for smoother scrolling
+            pageSnap: false, // Disable page snap for smoother scrolling
+            showScrollIndicators: true,
             defaultPage: _currentPage!,
             fitPolicy: FitPolicy.BOTH,
             preventLinkNavigation: false, // if set to true the link is handled in flutter

--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.m
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.m
@@ -1,10 +1,10 @@
 #import "./include/flutter_pdfview/FlutterPDFView.h"
 
 @implementation FLTPDFViewFactory {
-    NSObject<FlutterBinaryMessenger>* _messenger;
+    NSObject<FlutterBinaryMessenger> *_messenger;
 }
 
-- (instancetype)initWithMessenger:(NSObject<FlutterBinaryMessenger>*)messenger {
+- (instancetype)initWithMessenger:(NSObject<FlutterBinaryMessenger> *)messenger {
     self = [super init];
     if (self) {
         _messenger = messenger;
@@ -12,61 +12,70 @@
     return self;
 }
 
-- (NSObject<FlutterMessageCodec>*)createArgsCodec {
+- (NSObject<FlutterMessageCodec> *)createArgsCodec {
     return [FlutterStandardMessageCodec sharedInstance];
 }
 
-- (NSObject<FlutterPlatformView>*)createWithFrame:(CGRect)frame
-                                   viewIdentifier:(int64_t)viewId
-                                        arguments:(id _Nullable)args {
-    FLTPDFViewController* pdfviewController = [[FLTPDFViewController alloc] initWithFrame:frame
-                                                                           viewIdentifier:viewId
-                                                                                arguments:args
-                                                                          binaryMessenger:_messenger];
+- (NSObject<FlutterPlatformView> *)createWithFrame:(CGRect)frame
+                                    viewIdentifier:(int64_t)viewId
+                                         arguments:(id _Nullable)args {
+    FLTPDFViewController *pdfviewController =
+        [[FLTPDFViewController alloc] initWithFrame:frame
+                                     viewIdentifier:viewId
+                                          arguments:args
+                                    binaryMessenger:_messenger];
     return pdfviewController;
 }
 
 @end
 
 @implementation FLTPDFViewController {
-    FLTPDFView* _pdfView;
+    FLTPDFView *_pdfView;
     int64_t _viewId;
-    FlutterMethodChannel* _channel;
+    FlutterMethodChannel *_channel;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
                     arguments:(id _Nullable)args
-              binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger {
+              binaryMessenger:(NSObject<FlutterBinaryMessenger> *)messenger {
     self = [super init];
-    _pdfView = [[FLTPDFView alloc] initWithFrame:frame arguments:args controller:self];
+    _pdfView = [[FLTPDFView alloc] initWithFrame:frame
+                                       arguments:args
+                                      controller:self];
     _viewId = viewId;
 
-    @try  {
-        NSNumber* backgroundColor = args[@"backgroundColor"];
+    @try {
+        NSNumber *backgroundColor = args[@"backgroundColor"];
         if ([backgroundColor isKindOfClass:[NSNumber class]]) {
             unsigned int argb = [backgroundColor unsignedIntValue];
             CGFloat a = ((argb & 0xFF000000) >> 24) / 255.0;
             CGFloat r = ((argb & 0x00FF0000) >> 16) / 255.0;
             CGFloat g = ((argb & 0x0000FF00) >> 8) / 255.0;
             CGFloat b = (argb & 0x000000FF) / 255.0;
-            _pdfView.view.backgroundColor = [UIColor colorWithRed:r green:g blue:b alpha:a];
+            _pdfView.view.backgroundColor = [UIColor colorWithRed:r
+                                                            green:g
+                                                             blue:b
+                                                            alpha:a];
         }
     } @catch (NSException *exception) {
         NSLog(@"Exception while setting background color: %@", exception);
     }
 
-    NSString* channelName = [NSString stringWithFormat:@"plugins.endigo.io/pdfview_%lld", viewId];
-    _channel = [FlutterMethodChannel methodChannelWithName:channelName binaryMessenger:messenger];
+    NSString *channelName =
+        [NSString stringWithFormat:@"plugins.endigo.io/pdfview_%lld", viewId];
+    _channel = [FlutterMethodChannel methodChannelWithName:channelName
+                                           binaryMessenger:messenger];
     __weak __typeof__(self) weakSelf = self;
-    [_channel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
-        [weakSelf onMethodCall:call result:result];
-    }];
+    [_channel
+        setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
+          [weakSelf onMethodCall:call result:result];
+        }];
 
     return self;
 }
 
-- (void)onMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+- (void)onMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
     if ([[call method] isEqualToString:@"pageCount"]) {
         [_pdfView getPageCount:call result:result];
     } else if ([[call method] isEqualToString:@"currentPageSize"]) {
@@ -90,7 +99,10 @@
     } else if ([[call method] isEqualToString:@"reload"]) {
         [_pdfView reload:call result:result];
     } else if ([[call method] isEqualToString:@"getScreenshot"]) {
-        result([FlutterError errorWithCode:@"UNSUPPORTED" message:@"getScreenshot is not implemented on iOS" details:nil]);
+        result([FlutterError
+            errorWithCode:@"UNSUPPORTED"
+                  message:@"getScreenshot is not implemented on iOS"
+                  details:nil]);
     } else {
         result(FlutterMethodNotImplemented);
     }
@@ -100,24 +112,24 @@
     [_channel invokeMethod:name arguments:args];
 }
 
-- (UIView*)view {
+- (UIView *)view {
     return _pdfView;
 }
 
 @end
 
 @implementation FLTPDFView {
-    FLTPDFViewController* __weak _controller;
-    PDFView* _pdfView;
-    PDFDocument* _document;
-    UIScrollView* _scrollView;
-    NSNumber* _pageCount;
-    NSNumber* _currentPageIndex;
-    PDFDestination* _currentDestination;
+    FLTPDFViewController *__weak _controller;
+    PDFView *_pdfView;
+    PDFDocument *_document;
+    UIScrollView *_scrollView;
+    NSNumber *_pageCount;
+    NSNumber *_currentPageIndex;
+    PDFDestination *_currentDestination;
     BOOL _preventLinkNavigation;
     BOOL _autoSpacing;
-    PDFPage* _defaultPage;
-    PDFPage* _currentPage;
+    PDFPage *_defaultPage;
+    PDFPage *_currentPage;
     int _pageNo;
     BOOL _defaultPageSet;
     BOOL _isIPad;
@@ -138,10 +150,10 @@
         _controller = controller;
 
         // Detect if device is iPad
-        _isIPad = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
+        _isIPad = ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad);
         _isScrolling = NO;
 
-        _pdfView = [[PDFView alloc] initWithFrame: frame];
+        _pdfView = [[PDFView alloc] initWithFrame:frame];
         _pdfView.delegate = self;
 
         _autoSpacing = [args[@"autoSpacing"] boolValue];
@@ -151,38 +163,47 @@
 
         NSInteger defaultPage = [args[@"defaultPage"] integerValue];
 
-        NSString* filePath = args[@"filePath"];
-        FlutterStandardTypedData* pdfData = args[@"pdfData"];
+        NSString *filePath = args[@"filePath"];
+        FlutterStandardTypedData *pdfData = args[@"pdfData"];
 
         if ([filePath isKindOfClass:[NSString class]]) {
-            NSURL* sourcePDFUrl = [NSURL fileURLWithPath:filePath];
-            _document = [[PDFDocument alloc] initWithURL: sourcePDFUrl];
+            NSURL *sourcePDFUrl = [NSURL fileURLWithPath:filePath];
+            _document = [[PDFDocument alloc] initWithURL:sourcePDFUrl];
         } else if ([pdfData isKindOfClass:[FlutterStandardTypedData class]]) {
-            NSData* sourcePDFdata = [pdfData data];
-            _document = [[PDFDocument alloc] initWithData: sourcePDFdata];
+            NSData *sourcePDFdata = [pdfData data];
+            _document = [[PDFDocument alloc] initWithData:sourcePDFdata];
         }
 
-
-    if (_document == nil) {
-        __weak __typeof__(self) weakSelf = self;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            __strong __typeof__(weakSelf) strongSelf = weakSelf;
-            if (strongSelf == nil) { return; }
-            [strongSelf->_controller invokeChannelMethod:@"onError" arguments:@{@"error" : @"cannot create document: File not in PDF format or corrupted."}];
-        });
-    } else {
-        _pdfView.autoresizesSubviews = YES;
-        _pdfView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-        _pdfView.backgroundColor = [UIColor colorWithWhite:0.95 alpha:1.0];
-
-        BOOL swipeHorizontal = [args[@"swipeHorizontal"] boolValue];
-        if (swipeHorizontal) {
-            _pdfView.displayDirection = kPDFDisplayDirectionHorizontal;
+        if (_document == nil) {
+            __weak __typeof__(self) weakSelf = self;
+            dispatch_async(dispatch_get_main_queue(), ^{
+              __strong __typeof__(weakSelf) strongSelf = weakSelf;
+              if (strongSelf == nil) {
+                  return;
+              }
+              [strongSelf->_controller
+                  invokeChannelMethod:@"onError"
+                            arguments:@{
+                                @"error" : @"cannot create document: File not "
+                                           @"in PDF format or corrupted."
+                            }];
+            });
         } else {
-            _pdfView.displayDirection = kPDFDisplayDirectionVertical;
-        }
+            _pdfView.autoresizesSubviews = YES;
+            _pdfView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+            _pdfView.backgroundColor = [UIColor colorWithWhite:0.95 alpha:1.0];
 
-            _pdfView.autoScales = _autoSpacing;
+            BOOL swipeHorizontal = [args[@"swipeHorizontal"] boolValue];
+            if (swipeHorizontal) {
+                _pdfView.displayDirection = kPDFDisplayDirectionHorizontal;
+            } else {
+                _pdfView.displayDirection = kPDFDisplayDirectionVertical;
+            }
+
+            BOOL showScrollIndicators = [args[@"showScrollIndicators"] boolValue];
+            NSLog(@"show scroll %d", showScrollIndicators);
+
+            _pdfView.autoScales = YES;
 
             // On iPad, avoid conflicting display modes with page view controller
             if (_isIPad && pageFling && enableSwipe) {
@@ -198,17 +219,25 @@
 
             double maxZoomArg = [args[@"maxZoom"] doubleValue];
             double minZoomArg = [args[@"minZoom"] doubleValue];
-            if (maxZoomArg <= 0) { maxZoomArg = 4.0; }
-            if (minZoomArg <= 0) { minZoomArg = 1.0; }
+            if (maxZoomArg <= 0) {
+                maxZoomArg = 4.0;
+            }
+            if (minZoomArg <= 0) {
+                minZoomArg = 1.0;
+            }
             _maxScaleFactor = maxZoomArg;
             _minScaleFactor = minZoomArg;
 
-            NSString* password = args[@"password"];
-            if ([password isKindOfClass:[NSString class]] && [_pdfView.document isEncrypted]) {
+            NSString *password = args[@"password"];
+            if ([password isKindOfClass:[NSString class]] &&
+                [_pdfView.document isEncrypted]) {
                 [_pdfView.document unlockWithPassword:password];
             }
 
-            UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onDoubleTap:)];
+            UITapGestureRecognizer *tapGestureRecognizer =
+                [[UITapGestureRecognizer alloc]
+                    initWithTarget:self
+                            action:@selector(onDoubleTap:)];
             tapGestureRecognizer.numberOfTapsRequired = 2;
             tapGestureRecognizer.numberOfTouchesRequired = 1;
             tapGestureRecognizer.delegate = self;
@@ -218,66 +247,75 @@
 
             NSUInteger pageCount = [_document pageCount];
             if (pageCount == 0) {
-                [_controller invokeChannelMethod:@"onError" arguments:@{@"error" : @"PDF has no pages."}];
+                [_controller
+                    invokeChannelMethod:@"onError"
+                              arguments:@{@"error" : @"PDF has no pages."}];
                 return self;
             }
             if (pageCount <= defaultPage) {
                 defaultPage = pageCount - 1;
             }
 
-            _defaultPage = [_document pageAtIndex: defaultPage];
+            _defaultPage = [_document pageAtIndex:defaultPage];
 
             // Configure scroll view with defensive handling for iPad
             if (@available(iOS 11.0, *)) {
-                // Delay scroll view configuration to avoid conflicts during initialization
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                    @try {
-                        UIScrollView *scrollView = nil;
+                // Delay scroll view configuration to avoid conflicts during
+                // initialization
+                dispatch_after(
+                    dispatch_time(DISPATCH_TIME_NOW,
+                                  (int64_t)(0.1 * NSEC_PER_SEC)),
+                    dispatch_get_main_queue(), ^{
+                      @try {
+                          UIScrollView *scrollView = [self findScrollView:self->_pdfView];
 
-                        for (id subview in self->_pdfView.subviews) {
-                            if ([subview isKindOfClass:[UIScrollView class]]) {
-                                scrollView = subview;
-                                break;
-                            }
-                        }
+                          if (scrollView != nil) {
+                              // On iPad, use more conservative scroll configuration
+                              if (self->_isIPad) {
+                                  // Allow system to manage insets on iPad for better compatibility
+                                  scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
 
-                        if (scrollView != nil) {
-                            // On iPad, use more conservative scroll configuration
-                            if (self->_isIPad) {
-                                // Allow system to manage insets on iPad for better compatibility
-                                scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
+                                  // Set delegate to monitor scroll events
+                                  if ([scrollView.delegate isEqual:nil]) {
+                                      scrollView.delegate = (id<UIScrollViewDelegate>)self;
+                                  }
+                              } else {
+                                  // iPhone keeps existing behavior
+                                  scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+                                  if (@available(iOS 13.0, *)) {
+                                      scrollView.automaticallyAdjustsScrollIndicatorInsets = NO;
+                                  }
+                              }
 
-                                // Set delegate to monitor scroll events
-                                if ([scrollView.delegate isEqual:nil]) {
-                                    scrollView.delegate = (id <UIScrollViewDelegate>) self;
-                                }
-                            } else {
-                                // iPhone keeps existing behavior
-                                scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
-                                if (@available(iOS 13.0, *)) {
-                                    scrollView.automaticallyAdjustsScrollIndicatorInsets = NO;
-                                }
-                            }
-
-                            // Ensure scroll view recognizes gestures properly
-                            scrollView.delaysContentTouches = YES;
-                            scrollView.canCancelContentTouches = YES;
-                            self->_scrollView = scrollView;
-                        }
-                        __weak __typeof__(self) weakSelf = self;
-                        dispatch_async(dispatch_get_main_queue(), ^{
+                              // Ensure scroll view recognizes gestures properly
+                              scrollView.delaysContentTouches = YES;
+                              scrollView.canCancelContentTouches = YES;
+                              BOOL shouldShow = showScrollIndicators && !pageFling;
+                              scrollView.showsHorizontalScrollIndicator = shouldShow;
+                              scrollView.showsVerticalScrollIndicator = shouldShow;
+                              self->_scrollView = scrollView;
+                          }
+                          __weak __typeof__(self) weakSelf = self;
+                          dispatch_async(dispatch_get_main_queue(), ^{
                             __strong __typeof__(weakSelf) strongSelf = weakSelf;
-                            if (strongSelf == nil) { return; }
-                            [strongSelf handleRenderCompleted:[NSNumber numberWithUnsignedLong: [strongSelf->_document pageCount]]];
-                        });
-                    } @catch (NSException *exception) {
-                        NSLog(@"Warning: Failed to configure PDF scroll view: %@",
-                              exception.reason);
-                    }
-                });
+                            if (strongSelf == nil) {
+                                return;
+                            }
+                            [strongSelf handleRenderCompleted:
+                             [NSNumber numberWithUnsignedLong: [strongSelf->_document pageCount]]
+                            ];
+                          });
+                      } @catch (NSException *exception) {
+                          NSLog(@"Warning: Failed to configure PDF scroll  view: %@", exception.reason);
+                      }
+                    });
             }
 
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handlePageChanged:) name:PDFViewPageChangedNotification object:_pdfView];
+            [[NSNotificationCenter defaultCenter]
+                addObserver:self
+                   selector:@selector(handlePageChanged:)
+                       name:PDFViewPageChangedNotification
+                     object:_pdfView];
             [self addSubview:_pdfView];
         }
     }
@@ -286,6 +324,19 @@
 
 - (void)dealloc {
     [self stopObserving];
+}
+
+- (UIScrollView *)findScrollView:(UIView *)view {
+    if ([view isKindOfClass:[UIScrollView class]]) {
+        return (UIScrollView *)view;
+    }
+    for (UIView *subview in view.subviews) {
+        UIScrollView *scrollView = [self findScrollView:subview];
+        if (scrollView) {
+            return scrollView;
+        }
+    }
+    return nil;
 }
 
 - (void)startObserving {
@@ -300,18 +351,17 @@
 
 - (void)stopObserving {
     if (_scrollView && _isObserving) {
-        @try
-        {
+        @try {
             [_scrollView removeObserver:self forKeyPath:@"contentOffset"];
+        } @catch (NSException *__unused exception) {
         }
-        @catch (NSException * __unused exception) {}
         _isObserving = NO;
     }
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath
                       ofObject:(id)object
-                        change:(NSDictionary<NSKeyValueChangeKey,id> *)change
+                        change:(NSDictionary<NSKeyValueChangeKey, id> *)change
                        context:(void *)context {
     if ([keyPath isEqualToString:@"contentOffset"]) {
         CGPoint newOffset = [change[NSKeyValueChangeNewKey] CGPointValue];
@@ -319,11 +369,14 @@
         if (!CGPointEqualToPoint(newOffset, oldOffset)) {
             __weak __typeof__(self) weakSelf = self;
             dispatch_async(dispatch_get_main_queue(), ^{
-                [weakSelf handleOnDraw];
+              [weakSelf handleOnDraw];
             });
         }
     } else {
-        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+        [super observeValueForKeyPath:keyPath
+                             ofObject:object
+                               change:change
+                              context:context];
     }
 }
 
@@ -343,45 +396,52 @@
         CGFloat maxScale = fitScale * _maxScaleFactor;
         _pdfView.minScaleFactor = minScale;
         _pdfView.maxScaleFactor = fmax(maxScale, minScale);
-        
-        if (_autoSpacing) {
-            CGFloat clampedScale = fmin(fmax(fitScale, _pdfView.minScaleFactor), _pdfView.maxScaleFactor);
+
+        if (_autoSpacing || !_defaultPageSet) {
+            CGFloat clampedScale = fmin(fmax(fitScale, _pdfView.minScaleFactor),
+                                        _pdfView.maxScaleFactor);
             _pdfView.scaleFactor = clampedScale;
         }
 
         if (!_defaultPageSet && _defaultPage != nil) {
-            [_pdfView goToPage: _defaultPage];
+            [_pdfView goToPage:_defaultPage];
             _defaultPageSet = true;
         }
 
-        if (!_hasSentInitialPage && _defaultPageSet && _pdfView.document != nil && _pdfView.currentPage != nil) {
+        if (!_hasSentInitialPage && _defaultPageSet &&
+            _pdfView.document != nil && _pdfView.currentPage != nil) {
             _hasSentInitialPage = YES;
-            NSUInteger currentPageIndex = [_pdfView.document indexForPage:_pdfView.currentPage];
+            NSUInteger currentPageIndex =
+                [_pdfView.document indexForPage:_pdfView.currentPage];
             NSUInteger pageCount = [_pdfView.document pageCount];
-            [_controller invokeChannelMethod:@"onPageChanged" arguments:@{
-                @"page" : [NSNumber numberWithUnsignedLong:currentPageIndex],
-                @"total" : [NSNumber numberWithUnsignedLong:pageCount]
-            }];
+            [_controller
+                invokeChannelMethod:@"onPageChanged"
+                          arguments:@{
+                              @"page" : [NSNumber
+                                  numberWithUnsignedLong:currentPageIndex],
+                              @"total" :
+                                  [NSNumber numberWithUnsignedLong:pageCount]
+                          }];
         }
     } @catch (NSException *exception) {
         NSLog(@"Warning: Layout update failed: %@", exception.reason);
     }
 
     _currentPage = _pdfView.currentPage;
-    _pageCount = [NSNumber numberWithUnsignedLong: _pdfView.document.pageCount];
+    _pageCount = [NSNumber numberWithUnsignedLong:_pdfView.document.pageCount];
     _pageNo = (int)[_pdfView.document indexForPage:_currentPage] + 1;
 }
 
-- (UIView*)view {
+- (UIView *)view {
     return _pdfView;
 }
 
-
-- (void)getPageCount:(FlutterMethodCall*)call result:(FlutterResult)result {
+- (void)getPageCount:(FlutterMethodCall *)call result:(FlutterResult)result {
     result(_pageCount);
 }
 
-- (void)getCurrentPageSize:(FlutterMethodCall*)call result:(FlutterResult)result {
+- (void)getCurrentPageSize:(FlutterMethodCall *)call
+                    result:(FlutterResult)result {
     if (_pdfView.currentPage == nil) {
         result([FlutterError errorWithCode:@"INVALID_STATE"
                                    message:@"No page loaded"
@@ -389,38 +449,44 @@
         return;
     }
     CGRect bounds = [_pdfView.currentPage boundsForBox:kPDFDisplayBoxMediaBox];
-    NSArray *size = @[[NSNumber numberWithFloat:bounds.size.width], [NSNumber numberWithFloat:bounds.size.height]];
+    NSArray *size = @[
+        [NSNumber numberWithFloat:bounds.size.width],
+        [NSNumber numberWithFloat:bounds.size.height]
+    ];
     result(size);
 }
 
 - (NSArray *)calculatePosition {
-  float x = 0.0;
-  float y = 0.0;
+    float x = 0.0;
+    float y = 0.0;
 
-  if (_scrollView) {
-    if (@available(iOS 11.0, *)) {
-      x = -(_scrollView.contentOffset.x + _scrollView.adjustedContentInset.left);
-      y = -(_scrollView.contentOffset.y + _scrollView.adjustedContentInset.top);
-    } else {
-      x = -(_scrollView.contentOffset.x + _scrollView.contentInset.left);
-      y = -(_scrollView.contentOffset.y + _scrollView.contentInset.top);
+    if (_scrollView) {
+        if (@available(iOS 11.0, *)) {
+            x = -(_scrollView.contentOffset.x +
+                  _scrollView.adjustedContentInset.left);
+            y = -(_scrollView.contentOffset.y +
+                  _scrollView.adjustedContentInset.top);
+        } else {
+            x = -(_scrollView.contentOffset.x + _scrollView.contentInset.left);
+            y = -(_scrollView.contentOffset.y + _scrollView.contentInset.top);
+        }
     }
-  }
 
-  return
-      @[ [NSNumber numberWithFloat:x], [NSNumber numberWithFloat:y] ];
+    return @[ [NSNumber numberWithFloat:x], [NSNumber numberWithFloat:y] ];
 }
 
-- (void)getPosition:(FlutterMethodCall*)call result:(FlutterResult)result {
+- (void)getPosition:(FlutterMethodCall *)call result:(FlutterResult)result {
     if (_scrollView == nil) {
-        result([FlutterError errorWithCode:@"INVALID_STATE" message:@"PDFView not ready" details:nil]);
+        result([FlutterError errorWithCode:@"INVALID_STATE"
+                                   message:@"PDFView not ready"
+                                   details:nil]);
         return;
     }
     NSArray *position = [self calculatePosition];
     result(position);
 }
 
-- (void)getScale:(FlutterMethodCall*)call result:(FlutterResult)result {
+- (void)getScale:(FlutterMethodCall *)call result:(FlutterResult)result {
     NSNumber *scale = [NSNumber numberWithFloat:_pdfView.scaleFactor];
     result(scale);
 }
@@ -447,12 +513,16 @@
         targetOffset.x -= _scrollView.adjustedContentInset.left;
         targetOffset.y -= _scrollView.adjustedContentInset.top;
         minOffsetY = -_scrollView.adjustedContentInset.top;
-        maxOffsetY = MAX(minOffsetY, _scrollView.contentSize.height - _scrollView.bounds.size.height + _scrollView.adjustedContentInset.bottom);
+        maxOffsetY = MAX(minOffsetY, _scrollView.contentSize.height -
+                         _scrollView.bounds.size.height +
+                         _scrollView.adjustedContentInset.bottom);
     } else {
         targetOffset.x -= _scrollView.contentInset.left;
         targetOffset.y -= _scrollView.contentInset.top;
         minOffsetY = -_scrollView.contentInset.top;
-        maxOffsetY = MAX(minOffsetY, _scrollView.contentSize.height - _scrollView.bounds.size.height + _scrollView.contentInset.bottom);
+        maxOffsetY = MAX(minOffsetY, _scrollView.contentSize.height -
+                                         _scrollView.bounds.size.height +
+                                         _scrollView.contentInset.bottom);
     }
 
     if (targetOffset.y < minOffsetY) {
@@ -466,77 +536,92 @@
     result([NSNumber numberWithBool:YES]);
 }
 
-- (void)setScale:(FlutterMethodCall*)call result:(FlutterResult)result {
-    NSNumber* scale = call.arguments[@"scale"];
+- (void)setScale:(FlutterMethodCall *)call result:(FlutterResult)result {
+    NSNumber *scale = call.arguments[@"scale"];
     if (![scale isKindOfClass:[NSNumber class]] || scale.doubleValue <= 0.0) {
-        result([FlutterError errorWithCode:@"INVALID_ARGS" message:@"scale must be > 0" details:nil]);
+        result([FlutterError errorWithCode:@"INVALID_ARGS"
+                                   message:@"scale must be > 0"
+                                   details:nil]);
         return;
     }
     _pdfView.scaleFactor = scale.doubleValue;
-    result([NSNumber numberWithBool: YES]);
+    result([NSNumber numberWithBool:YES]);
 }
 
-- (void)getCurrentPage:(FlutterMethodCall*)call result:(FlutterResult)result {
-    _currentPageIndex = [NSNumber numberWithUnsignedLong: [_pdfView.document indexForPage: _pdfView.currentPage]];
+- (void)getCurrentPage:(FlutterMethodCall *)call result:(FlutterResult)result {
+    _currentPageIndex = [NSNumber
+        numberWithUnsignedLong:[_pdfView.document
+                                   indexForPage:_pdfView.currentPage]];
     result(_currentPageIndex);
 }
 
-- (void)reload:(FlutterMethodCall*)call result:(FlutterResult)result {
+- (void)reload:(FlutterMethodCall *)call result:(FlutterResult)result {
     _pdfView.document = _document;
     if (_document.pageCount > 0) {
         PDFPage *firstPage = [_document pageAtIndex:0];
         [_pdfView goToPage:firstPage];
 
         CGRect pageBounds = [firstPage boundsForBox:kPDFDisplayBoxMediaBox];
-        [self->_pdfView goToRect:CGRectMake(0, pageBounds.size.height, 1, 1) onPage:firstPage];
+        [self->_pdfView goToRect:CGRectMake(0, pageBounds.size.height, 1, 1)
+                          onPage:firstPage];
 
         _pdfView.scaleFactor = _pdfView.scaleFactorForSizeToFit;
     }
 
-    result([NSNumber numberWithBool: YES]);
+    result([NSNumber numberWithBool:YES]);
 }
 
-- (void)setPage:(FlutterMethodCall*)call result:(FlutterResult)result {
-    NSDictionary<NSString*, NSNumber*>* arguments = [call arguments];
-    NSNumber* page = arguments[@"page"];
+- (void)setPage:(FlutterMethodCall *)call result:(FlutterResult)result {
+    NSDictionary<NSString *, NSNumber *> *arguments = [call arguments];
+    NSNumber *page = arguments[@"page"];
     NSUInteger pageIndex = page.unsignedLongValue;
     NSUInteger pageCount = [_pdfView.document pageCount];
     if (pageIndex >= pageCount) {
-        result([FlutterError errorWithCode:@"INVALID_PAGE" message:@"Page index out of bounds" details:nil]);
+        result([FlutterError errorWithCode:@"INVALID_PAGE"
+                                   message:@"Page index out of bounds"
+                                   details:nil]);
         return;
     }
 
-    [_pdfView goToPage: [_pdfView.document pageAtIndex: pageIndex ]];
-    result([NSNumber numberWithBool: YES]);
+    [_pdfView goToPage:[_pdfView.document pageAtIndex:pageIndex]];
+    result([NSNumber numberWithBool:YES]);
 }
 
-- (void)onUpdateSettings:(FlutterMethodCall*)call result:(FlutterResult)result {
+- (void)onUpdateSettings:(FlutterMethodCall *)call
+                  result:(FlutterResult)result {
     result(nil);
 }
 
-- (void)setZoomLimits:(FlutterMethodCall*)call result:(FlutterResult)result {
-    NSDictionary<NSString*, NSNumber*>* arguments = [call arguments];
-    NSNumber* minZoom = arguments[@"minZoom"];
-    NSNumber* maxZoom = arguments[@"maxZoom"];
+- (void)setZoomLimits:(FlutterMethodCall *)call result:(FlutterResult)result {
+    NSDictionary<NSString *, NSNumber *> *arguments = [call arguments];
+    NSNumber *minZoom = arguments[@"minZoom"];
+    NSNumber *maxZoom = arguments[@"maxZoom"];
     float minScale = minZoom.floatValue * _pdfView.scaleFactorForSizeToFit;
     float maxScale = maxZoom.floatValue * _pdfView.scaleFactorForSizeToFit;
     _pdfView.minScaleFactor = minScale != 0.0 ? minScale : minZoom.floatValue;
     _pdfView.maxScaleFactor = maxScale != 0.0 ? maxScale : maxZoom.floatValue;
-    result([NSNumber numberWithBool: YES]);
+    result([NSNumber numberWithBool:YES]);
 }
 
--(void)handlePageChanged:(NSNotification*)notification {
+- (void)handlePageChanged:(NSNotification *)notification {
     _hasSentInitialPage = YES;
     _currentPage = _pdfView.currentPage;
     _pageNo = (int)[_pdfView.document indexForPage:_currentPage] + 1;
-    [_controller invokeChannelMethod:@"onPageChanged" arguments:@{@"page" : [NSNumber numberWithUnsignedLong: _pageNo - 1], @"total" : [NSNumber numberWithUnsignedLong: [_pdfView.document pageCount]]}];
+    [_controller
+        invokeChannelMethod:@"onPageChanged"
+                  arguments:@{
+                      @"page" : [NSNumber numberWithUnsignedLong:_pageNo - 1],
+                      @"total" : [NSNumber
+                          numberWithUnsignedLong:[_pdfView.document pageCount]]
+                  }];
 }
 
--(void)handleRenderCompleted: (NSNumber*)pages {
+- (void)handleRenderCompleted:(NSNumber *)pages {
     [_controller invokeChannelMethod:@"onRender" arguments:@{@"pages" : pages}];
     if (!_didLoadComplete) {
         _didLoadComplete = YES;
-        [_controller invokeChannelMethod:@"onLoadComplete" arguments:@{@"pages" : pages}];
+        [_controller invokeChannelMethod:@"onLoadComplete"
+                               arguments:@{@"pages" : pages}];
     }
     [self startObserving];
 }
@@ -544,28 +629,32 @@
 - (void)handleOnDraw {
     NSArray *position = [self calculatePosition];
     [_controller invokeChannelMethod:@"onDraw"
-                           arguments:@{@"pdfXOffset" : [position objectAtIndex:0],
-                                       @"pdfYOffset" :  [position objectAtIndex:1],
-                                       @"pdfScale" : [NSNumber numberWithFloat:_pdfView.scaleFactor]}
-    ];
+                           arguments:@{
+                               @"pdfXOffset" : [position objectAtIndex:0],
+                               @"pdfYOffset" : [position objectAtIndex:1],
+                               @"pdfScale" : [NSNumber
+                                   numberWithFloat:_pdfView.scaleFactor]
+                           }];
 }
 
-- (void)PDFViewWillClickOnLink:(PDFView *)sender
-                       withURL:(NSURL *)url{
-    if (!_preventLinkNavigation){
+- (void)PDFViewWillClickOnLink:(PDFView *)sender withURL:(NSURL *)url {
+    if (!_preventLinkNavigation) {
         NSDictionary *options = @{};
-        [[UIApplication sharedApplication] openURL:url options:options completionHandler:^(BOOL success) {
-            if (success) {
-                NSLog(@"URL opened successfully");
-            } else {
-                NSLog(@"Failed to open URL");
-            }
-        } ];
+        [[UIApplication sharedApplication] openURL:url
+                                           options:options
+                                 completionHandler:^(BOOL success) {
+                                   if (success) {
+                                       NSLog(@"URL opened successfully");
+                                   } else {
+                                       NSLog(@"Failed to open URL");
+                                   }
+                                 }];
     }
-    [_controller invokeChannelMethod:@"onLinkHandler" arguments:url.absoluteString];
+    [_controller invokeChannelMethod:@"onLinkHandler"
+                           arguments:url.absoluteString];
 }
 
-- (void) onDoubleTap: (UITapGestureRecognizer *)recognizer {
+- (void)onDoubleTap:(UITapGestureRecognizer *)recognizer {
     if (recognizer.state == UIGestureRecognizerStateEnded) {
         // Prevent zooming during scrolling
         if (_isScrolling) {
@@ -575,20 +664,30 @@
         @try {
             if ([_pdfView scaleFactor] == _pdfView.scaleFactorForSizeToFit) {
                 CGPoint point = [recognizer locationInView:_pdfView];
-                PDFPage* page = [_pdfView pageForPoint:point nearest:YES];
+                PDFPage *page = [_pdfView pageForPoint:point nearest:YES];
                 if (page != nil) {
                     PDFPoint pdfPoint = [_pdfView convertPoint:point toPage:page];
                     PDFRect rect = [page boundsForBox:kPDFDisplayBoxMediaBox];
-                    PDFDestination* destination = [[PDFDestination alloc] initWithPage:page atPoint:CGPointMake(pdfPoint.x - (rect.size.width / 4),pdfPoint.y + (rect.size.height / 4))];
-                    [UIView animateWithDuration:0.2 animations:^{
-                        self-> _pdfView.scaleFactor = self->_pdfView.scaleFactorForSizeToFit * 2;
-                        [self->_pdfView goToDestination:destination];
-                    }];
+                    PDFDestination *destination = [[PDFDestination alloc]
+                        initWithPage:page
+                             atPoint:CGPointMake(
+                                         pdfPoint.x - (rect.size.width / 4),
+                                         pdfPoint.y + (rect.size.height / 4))];
+                    [UIView
+                        animateWithDuration:0.2
+                                 animations:^{
+                                   self->_pdfView.scaleFactor =
+                                       self->_pdfView.scaleFactorForSizeToFit *
+                                       2;
+                                   [self->_pdfView goToDestination:destination];
+                                 }];
                 }
             } else {
-                [UIView animateWithDuration:0.2 animations:^{
-                    self->_pdfView.scaleFactor = self->_pdfView.scaleFactorForSizeToFit;
-                }];
+                [UIView animateWithDuration:0.2
+                                 animations:^{
+                                   self->_pdfView.scaleFactor =
+                                       self->_pdfView.scaleFactorForSizeToFit;
+                                 }];
             }
         } @catch (NSException *exception) {
             NSLog(@"Warning: Double-tap zoom failed: %@", exception.reason);
@@ -598,7 +697,9 @@
 
 #pragma mark - UIGestureRecognizerDelegate
 
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:
+        (UIGestureRecognizer *)otherGestureRecognizer {
     // Allow double-tap to work with scroll gestures
     if ([gestureRecognizer isKindOfClass:[UITapGestureRecognizer class]]) {
         return YES;

--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.m
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.m
@@ -276,7 +276,7 @@
                                   scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
 
                                   // Set delegate to monitor scroll events
-                                  if ([scrollView.delegate isEqual:nil]) {
+                                  if (scrollView.delegate == nil) {
                                       scrollView.delegate = (id<UIScrollViewDelegate>)self;
                                   }
                               } else {

--- a/lib/flutter_pdfview.dart
+++ b/lib/flutter_pdfview.dart
@@ -13,8 +13,7 @@ typedef ErrorCallback = void Function(dynamic error);
 typedef PageErrorCallback = void Function(int? page, dynamic error);
 typedef LinkHandlerCallback = void Function(String? uri);
 typedef LoadCompleteCallback = void Function(int? pages);
-typedef DrawCallback = void Function(
-    double pdfXOffset, double pdfYOffset, double pdfScale);
+typedef DrawCallback = void Function(double pdfXOffset, double pdfYOffset, double pdfScale);
 
 enum FitPolicy { WIDTH, HEIGHT, BOTH }
 
@@ -34,6 +33,7 @@ class PDFView extends StatefulWidget {
     this.gestureRecognizers,
     this.enableSwipe = true,
     this.swipeHorizontal = false,
+    this.showScrollIndicators = false,
     this.password,
     this.nightMode = false,
     this.autoSpacing = true,
@@ -102,6 +102,10 @@ class PDFView extends StatefulWidget {
   /// Indicates whether or not the user can swipe horizontally to change pages in the PDF document. If set to true, horizontal swiping is enabled.
   final bool swipeHorizontal;
 
+  /// Indicates whether or not the PDF Viewer should show scroll indicators - scroll handles on Android and scrollbars on iOS
+  /// NB: on iOS, if pageFling is set to true, scroll indicators will not show
+  final bool showScrollIndicators;
+
   /// Represents the password for a password-protected PDF document. It can be nullable
   final String? password;
 
@@ -114,7 +118,8 @@ class PDFView extends StatefulWidget {
   /// Indicates whether or not the user can "fling" pages in the PDF document. If set to true, page flinging is enabled.
   final bool pageFling;
 
-  /// Indicates whether or not the viewer snaps to a page after the user has scrolled to it. If set to true, snapping is enabled.
+  /// Indicates whether or not the viewer snaps to a page after the user has scrolled to it.
+  /// If set to true, snapping is enabled. No effect in iOS
   final bool pageSnap;
 
   /// Controls whether the PDF renderer uses anti-aliasing (Android only).
@@ -156,8 +161,7 @@ class PDFView extends StatefulWidget {
 }
 
 class _PDFViewState extends State<PDFView> {
-  final Completer<PDFViewController> _controller =
-      Completer<PDFViewController>();
+  final Completer<PDFViewController> _controller = Completer<PDFViewController>();
 
   @override
   Widget build(BuildContext context) {
@@ -170,8 +174,8 @@ class _PDFViewState extends State<PDFView> {
         ) {
           return AndroidViewSurface(
             controller: controller as AndroidViewController,
-            gestureRecognizers: widget.gestureRecognizers ??
-                const <Factory<OneSequenceGestureRecognizer>>{},
+            gestureRecognizers:
+                widget.gestureRecognizers ?? const <Factory<OneSequenceGestureRecognizer>>{},
             hitTestBehavior: PlatformViewHitTestBehavior.opaque,
           );
         },
@@ -199,8 +203,7 @@ class _PDFViewState extends State<PDFView> {
         creationParamsCodec: const StandardMessageCodec(),
       );
     }
-    return Text(
-        '$defaultTargetPlatform is not yet supported by the pdfview_flutter plugin');
+    return Text('$defaultTargetPlatform is not yet supported by the pdfview_flutter plugin');
   }
 
   void _onPlatformViewCreated(int id) {
@@ -214,14 +217,12 @@ class _PDFViewState extends State<PDFView> {
   @override
   void didUpdateWidget(PDFView oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _controller.future.then(
-        (PDFViewController controller) => controller._updateWidget(widget));
+    _controller.future.then((PDFViewController controller) => controller._updateWidget(widget));
   }
 
   @override
   void dispose() {
-    _controller.future
-        .then((PDFViewController controller) => controller.dispose());
+    _controller.future.then((PDFViewController controller) => controller.dispose());
     super.dispose();
   }
 }
@@ -262,6 +263,7 @@ class _PDFViewSettings {
   _PDFViewSettings({
     this.enableSwipe,
     this.swipeHorizontal,
+    this.showScrollIndicators,
     this.password,
     this.nightMode,
     this.autoSpacing,
@@ -283,6 +285,7 @@ class _PDFViewSettings {
     return _PDFViewSettings(
       enableSwipe: widget.enableSwipe,
       swipeHorizontal: widget.swipeHorizontal,
+      showScrollIndicators: widget.showScrollIndicators,
       password: widget.password,
       nightMode: widget.nightMode,
       autoSpacing: widget.autoSpacing,
@@ -303,6 +306,7 @@ class _PDFViewSettings {
 
   final bool? enableSwipe;
   final bool? swipeHorizontal;
+  final bool? showScrollIndicators;
   final String? password;
   final bool? nightMode;
   final bool? autoSpacing;
@@ -325,6 +329,7 @@ class _PDFViewSettings {
     return <String, dynamic>{
       'enableSwipe': enableSwipe,
       'swipeHorizontal': swipeHorizontal,
+      'showScrollIndicators': showScrollIndicators,
       'password': password,
       'nightMode': nightMode,
       'autoSpacing': autoSpacing,
@@ -409,8 +414,7 @@ class PDFViewController {
         widget.onError?.call(call.arguments['error']);
         return null;
       case 'onPageError':
-        widget.onPageError
-            ?.call(call.arguments['page'], call.arguments['error']);
+        widget.onPageError?.call(call.arguments['page'], call.arguments['error']);
         return null;
       case 'onLinkHandler':
         widget.onLinkHandler?.call(call.arguments);
@@ -419,12 +423,11 @@ class PDFViewController {
         widget.onLoadComplete?.call(call.arguments['pages']);
         return null;
       case 'onDraw':
-        widget.onDraw?.call(call.arguments['pdfXOffset'],
-            call.arguments['pdfYOffset'], call.arguments['pdfScale']);
+        widget.onDraw?.call(
+            call.arguments['pdfXOffset'], call.arguments['pdfYOffset'], call.arguments['pdfScale']);
         return null;
     }
-    throw MissingPluginException(
-        '${call.method} was invoked but has no handler');
+    throw MissingPluginException('${call.method} was invoked but has no handler');
   }
 
   Future<int?> getPageCount() async {
@@ -461,8 +464,7 @@ class PDFViewController {
       await _setPositionCompleter!.future;
     }
     _setPositionCompleter = Completer<void>();
-    final bool isSet =
-        await _channel.invokeMethod('setPosition', <String, double>{
+    final bool isSet = await _channel.invokeMethod('setPosition', <String, double>{
       'xPos': position.dx,
       'yPos': position.dy,
     });
@@ -486,8 +488,7 @@ class PDFViewController {
     return isSet;
   }
 
-  Future<bool> setZoomLimits(
-      double minZoom, double midZoom, double maxZoom) async {
+  Future<bool> setZoomLimits(double minZoom, double midZoom, double maxZoom) async {
     return await _channel.invokeMethod<bool>('setZoomLimits', <String, dynamic>{
           'minZoom': minZoom,
           'midZoom': midZoom,
@@ -516,8 +517,7 @@ class PDFViewController {
   }
 
   Future<bool?> setPage(int page) async {
-    final bool? isSet =
-        await _channel.invokeMethod('setPage', <String, dynamic>{
+    final bool? isSet = await _channel.invokeMethod('setPage', <String, dynamic>{
       'page': page,
     });
     return isSet;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/endigo/flutter_pdfview
 
 topics:
   - pdf
-  - annotations
-  - drawing
+  - viewer
+  - native
 
 environment:
   sdk: ">=3.6.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,11 @@ description: A Flutter plugin that provides a PDFView widget on Android and iOS.
 version: 1.4.5-beta.2
 homepage: https://github.com/endigo/flutter_pdfview
 
+topics:
+  - pdf
+  - annotations
+  - drawing
+
 environment:
   sdk: ">=3.6.0 <4.0.0"
   flutter: ">=3.27.0"


### PR DESCRIPTION
Fix for issue #337 
Involves including a `showScrollIndicators` parameter (default false), and showing scroll handles on Android if true, and scroll indicator on iOS if true AND if pageFling is false. 
There is an issue in iOS with scroll indicators when `usePageViewController` is set to YES, so showScrollIndicators is ignored in this case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added showScrollIndicators option to control native scroll indicator visibility.
  * PDF loading supports data-based input and exposes view improvements for better integration.

* **Bug Fixes**
  * Improved error reporting for document load failures and empty PDFs.
  * More robust scroll/zoom behavior with consistent min/max/defaults and safer position/scale/page handling.
  * Better handling of encrypted PDFs with password support.

* **Documentation**
  * README updated to document new option and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->