### PR TITLE
feat(android): luminance-invert colorMode via hardware layer

### DIFF
--- a/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
+++ b/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
@@ -3,6 +3,9 @@ package io.endigo.plugins.pdfviewflutter
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.Paint
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
@@ -44,6 +47,15 @@ class FlutterPDFView(
     private val displayDensity: Float
     private val mainHandler = Handler(Looper.getMainLooper())
 
+    /**
+     * Active color transform, or null for light mode. Stored as the matrix
+     * (not a boolean) so sepia/soft-dark is a one-constant addition later.
+     */
+    private var colorMatrix: FloatArray? = null
+
+    /** Last background requested by Dart (pre-compensation), or null. */
+    private var requestedBackgroundColor: Int? = null
+
     @Volatile
     private var disposed = false
 
@@ -76,11 +88,10 @@ class FlutterPDFView(
             }
         }
 
-        val backgroundColor = params["backgroundColor"]
-        if (backgroundColor != null) {
-            val color = (backgroundColor as Number).toInt()
-            view.setBackgroundColor(color)
-        }
+        // Record creation-time theme; single applyColorTheme (no loadPages yet).
+        requestedBackgroundColor = (params["backgroundColor"] as? Number)?.toInt()
+        colorMatrix = resolveColorMatrix(params)
+        applyColorTheme(reloadPages = false)
 
         // Defer load until the view has a non-zero size so Pdfium does not render
         // into a zero-sized / unattached surface (#298 blank, #280 quick-open crash).
@@ -141,11 +152,12 @@ class FlutterPDFView(
         }
 
         if (config != null) {
+            // Do not call nightMode() — hardware-layer colorMode is applied via
+            // applyColorTheme(); composing both would double-invert.
             config
                 .enableSwipe(getBoolean(params, "enableSwipe"))
                 .swipeHorizontal(getBoolean(params, "swipeHorizontal"))
                 .password(getString(params, "password"))
-                .nightMode(getBoolean(params, "nightMode"))
                 .autoSpacing(getBoolean(params, "autoSpacing"))
                 .pageFling(getBoolean(params, "pageFling"))
                 .pageSnap(getBoolean(params, "pageSnap"))
@@ -375,7 +387,19 @@ class FlutterPDFView(
         }
         val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
-        view.draw(canvas)
+        // View.draw bypasses the hardware layer paint, so without saveLayer
+        // screenshots would silently stay light-mode while dark is on screen.
+        val matrix = colorMatrix
+        if (matrix != null) {
+            val paint = Paint().apply {
+                colorFilter = ColorMatrixColorFilter(ColorMatrix(matrix.copyOf()))
+            }
+            canvas.saveLayer(null, paint)
+            view.draw(canvas)
+            canvas.restore()
+        } else {
+            view.draw(canvas)
+        }
         return bitmap
     }
 
@@ -459,15 +483,31 @@ class FlutterPDFView(
         if (disposed || view == null) {
             return
         }
+        // colorMode + backgroundColor arrive together; only record during the
+        // loop, then a single applyColorTheme() so gutter compensation sees the
+        // final mode and loadPages runs once.
+        var colorThemeDirty = false
         for (key in settings.keys) {
             when (key) {
                 "enableSwipe" -> view.setSwipeEnabled(getBoolean(settings, key))
+                "colorMode" -> {
+                    colorMatrix = matrixForColorMode(settings[key] as? String)
+                    colorThemeDirty = true
+                }
+                "backgroundColor" -> {
+                    val bg = settings[key]
+                    requestedBackgroundColor = if (bg is Number) bg.toInt() else null
+                    colorThemeDirty = true
+                }
+                // Legacy: map nightMode through the color-matrix path; never
+                // call setNightMode (would compose with the layer and double-invert).
                 "nightMode" -> {
-                    view.setNightMode(getBoolean(settings, key))
-                    // Night mode is applied when pages are (re)rendered; AndroidPdfViewer
-                    // caches page bitmaps so invalidate() alone is not enough.
-                    view.loadPages()
-                    view.invalidate()
+                    colorMatrix = if (getBoolean(settings, key)) {
+                        PdfColorMatrix.LUMINANCE_INVERT
+                    } else {
+                        null
+                    }
+                    colorThemeDirty = true
                 }
                 "pageFling" -> view.setPageFling(getBoolean(settings, key))
                 "pageSnap" -> view.setPageSnap(getBoolean(settings, key))
@@ -479,6 +519,67 @@ class FlutterPDFView(
                 "minZoom" -> view.minZoom = getFloat(settings, key, DEFAULT_MIN_ZOOM)
                 else -> throw IllegalArgumentException("Unknown PDFView setting: $key")
             }
+        }
+        if (colorThemeDirty) {
+            applyColorTheme(reloadPages = true)
+        }
+    }
+
+    /**
+     * Apply [colorMatrix] as a hardware-layer [ColorMatrixColorFilter] and set
+     * the gutter background.
+     *
+     * Because M is an involution, dark mode sets the view background to
+     * `M(requestedBackgroundColor)` so the layer renders the color Dart asked
+     * for. Background is always `null` (never TRANSPARENT): AndroidPdfViewer
+     * self-fills only when `getBackground() == null`; with a dark layer that
+     * fill becomes black.
+     */
+    private fun applyColorTheme(reloadPages: Boolean) {
+        val view = pdfView
+        if (disposed || view == null) {
+            return
+        }
+        val matrix = colorMatrix
+        if (matrix != null) {
+            val paint = Paint().apply {
+                colorFilter = ColorMatrixColorFilter(ColorMatrix(matrix.copyOf()))
+            }
+            view.setLayerType(View.LAYER_TYPE_HARDWARE, paint)
+            val bg = requestedBackgroundColor
+            if (bg != null) {
+                view.setBackgroundColor(PdfColorMatrix.transformColor(bg, matrix))
+            } else {
+                view.background = null
+            }
+        } else {
+            view.setLayerType(View.LAYER_TYPE_NONE, null)
+            val bg = requestedBackgroundColor
+            if (bg != null) {
+                view.setBackgroundColor(bg)
+            } else {
+                view.background = null
+            }
+        }
+        if (reloadPages && view.pageCount > 0) {
+            // Cached page bitmaps must be flushed; invalidate alone is not enough.
+            view.loadPages()
+            view.invalidate()
+        }
+    }
+
+    private fun resolveColorMatrix(params: Map<String, Any?>): FloatArray? {
+        if (params.containsKey("colorMode")) {
+            return matrixForColorMode(params["colorMode"] as? String)
+        }
+        // Creation-time fallback while Dart still sends nightMode.
+        return if (getBoolean(params, "nightMode")) PdfColorMatrix.LUMINANCE_INVERT else null
+    }
+
+    private fun matrixForColorMode(mode: String?): FloatArray? {
+        return when (mode) {
+            "dark" -> PdfColorMatrix.LUMINANCE_INVERT
+            else -> null // "light", null, or unknown → light
         }
     }
 

--- a/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/PdfColorMatrix.kt
+++ b/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/PdfColorMatrix.kt
@@ -1,0 +1,78 @@
+package io.endigo.plugins.pdfviewflutter
+
+/**
+ * Shared 4×5 color-matrix constants for PDF color modes.
+ *
+ * No Android framework imports — plain JUnit can exercise the math without
+ * Robolectric. Matrices use the Android [ColorMatrix] layout (RGB in 0–255,
+ * fifth column is additive bias).
+ *
+ * Luminance invert preserves hue while swapping light/dark: white↔black, but
+ * red (255,0,0) stays reddish rather than becoming cyan. Algebraically
+ * `A = I − (2/3)J` with bias +255; linear part has eigenvalues −1 on the grey
+ * axis and +1 on the zero-sum plane, so **M is an involution** (`M(M(v)) == v`)
+ * wherever the intermediate stays in range. Saturated extremes can clip
+ * (worst case ~#00FFFF); realistic gutter colors are safe.
+ *
+ * Store the matrix (`FloatArray?`, null = light) rather than a boolean so a
+ * future sepia/soft-dark mode is a new constant, not an API change.
+ */
+object PdfColorMatrix {
+
+    private const val ONE_THIRD = 1f / 3f
+    private const val NEG_TWO_THIRDS = -2f / 3f
+
+    /**
+     * Luminance-preserving invert (dark mode). 20 floats, row-major 4×5.
+     *
+     * ```
+     *  1/3  -2/3  -2/3  0  255
+     * -2/3   1/3  -2/3  0  255
+     * -2/3  -2/3   1/3  0  255
+     *  0     0     0    1    0
+     * ```
+     */
+    @JvmField
+    val LUMINANCE_INVERT: FloatArray = floatArrayOf(
+        ONE_THIRD, NEG_TWO_THIRDS, NEG_TWO_THIRDS, 0f, 255f,
+        NEG_TWO_THIRDS, ONE_THIRD, NEG_TWO_THIRDS, 0f, 255f,
+        NEG_TWO_THIRDS, NEG_TWO_THIRDS, ONE_THIRD, 0f, 255f,
+        0f, 0f, 0f, 1f, 0f
+    )
+
+    /**
+     * Apply a 4×5 color matrix to an ARGB packed color (components 0–255).
+     * Result channels are clamped to [0, 255].
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun transformColor(argb: Int, matrix: FloatArray = LUMINANCE_INVERT): Int {
+        val a = ((argb ushr 24) and 0xFF).toFloat()
+        val r = ((argb ushr 16) and 0xFF).toFloat()
+        val g = ((argb ushr 8) and 0xFF).toFloat()
+        val b = (argb and 0xFF).toFloat()
+
+        val rOut = clamp255(
+            matrix[0] * r + matrix[1] * g + matrix[2] * b + matrix[3] * a + matrix[4]
+        )
+        val gOut = clamp255(
+            matrix[5] * r + matrix[6] * g + matrix[7] * b + matrix[8] * a + matrix[9]
+        )
+        val bOut = clamp255(
+            matrix[10] * r + matrix[11] * g + matrix[12] * b + matrix[13] * a + matrix[14]
+        )
+        val aOut = clamp255(
+            matrix[15] * r + matrix[16] * g + matrix[17] * b + matrix[18] * a + matrix[19]
+        )
+
+        return (aOut shl 24) or (rOut shl 16) or (gOut shl 8) or bOut
+    }
+
+    private fun clamp255(value: Float): Int {
+        return when {
+            value <= 0f -> 0
+            value >= 255f -> 255
+            else -> (value + 0.5f).toInt()
+        }
+    }
+}

--- a/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewColorModeTest.java
+++ b/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewColorModeTest.java
@@ -1,0 +1,161 @@
+package io.endigo.plugins.pdfviewflutter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import android.content.Context;
+import android.graphics.drawable.ColorDrawable;
+import android.view.View;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+
+/**
+ * {@code applySettings} is private, so drive
+ * {@link FlutterPDFView#onMethodCall} with {@code updateSettings} and assert
+ * {@code colorMode} / {@code backgroundColor} are accepted (not
+ * {@link IllegalArgumentException}) and applied via the hardware-layer path.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 35)
+public class FlutterPDFViewColorModeTest {
+
+    private Context context;
+    private BinaryMessenger messenger;
+    private int nextViewId;
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.getApplication();
+        messenger = mock(BinaryMessenger.class);
+    }
+
+    private FlutterPDFView newView(Map<String, Object> params) {
+        return new FlutterPDFView(context, messenger, nextViewId++, params);
+    }
+
+    private void updateSettings(FlutterPDFView view, Map<String, Object> settings) {
+        MethodChannel.Result result = mock(MethodChannel.Result.class);
+        view.onMethodCall(new MethodCall("updateSettings", settings), result);
+        verify(result).success(isNull());
+    }
+
+    @Test
+    public void updateSettings_acceptsColorModeDark() {
+        FlutterPDFView pdf = newView(new HashMap<>());
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("colorMode", "dark");
+        updateSettings(pdf, settings);
+
+        View view = pdf.getView();
+        assertEquals(View.LAYER_TYPE_HARDWARE, view.getLayerType());
+    }
+
+    @Test
+    public void updateSettings_acceptsColorModeLight() {
+        Map<String, Object> create = new HashMap<>();
+        create.put("colorMode", "dark");
+        FlutterPDFView pdf = newView(create);
+
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("colorMode", "light");
+        updateSettings(pdf, settings);
+
+        View view = pdf.getView();
+        assertEquals(View.LAYER_TYPE_NONE, view.getLayerType());
+    }
+
+    @Test
+    public void updateSettings_acceptsBackgroundColor() {
+        FlutterPDFView pdf = newView(new HashMap<>());
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("backgroundColor", 0xFFFEF7FF);
+        updateSettings(pdf, settings);
+
+        View view = pdf.getView();
+        ColorDrawable bg = (ColorDrawable) view.getBackground();
+        assertEquals(0xFFFEF7FF, bg.getColor());
+    }
+
+    @Test
+    public void updateSettings_colorModeAndBackgroundColor_together_darkCompensatesGutter() {
+        // Both keys in one map must not throw and must compensate gutter with M(bg).
+        FlutterPDFView pdf = newView(new HashMap<>());
+        int requested = 0xFF121212;
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("colorMode", "dark");
+        settings.put("backgroundColor", requested);
+        updateSettings(pdf, settings);
+
+        View view = pdf.getView();
+        assertEquals(View.LAYER_TYPE_HARDWARE, view.getLayerType());
+        ColorDrawable bg = (ColorDrawable) view.getBackground();
+        int expected = PdfColorMatrix.transformColor(requested, PdfColorMatrix.LUMINANCE_INVERT);
+        assertEquals(expected, bg.getColor());
+    }
+
+    @Test
+    public void updateSettings_darkWithoutBackground_setsNullBackground() {
+        FlutterPDFView pdf = newView(new HashMap<>());
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("colorMode", "dark");
+        updateSettings(pdf, settings);
+
+        View view = pdf.getView();
+        assertEquals(View.LAYER_TYPE_HARDWARE, view.getLayerType());
+        // Never TRANSPARENT — AndroidPdfViewer self-fills only when background is null.
+        assertNull(view.getBackground());
+    }
+
+    @Test
+    public void updateSettings_legacyNightMode_mapsToHardwareLayer() {
+        FlutterPDFView pdf = newView(new HashMap<>());
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("nightMode", true);
+        updateSettings(pdf, settings);
+
+        assertEquals(View.LAYER_TYPE_HARDWARE, pdf.getView().getLayerType());
+    }
+
+    @Test
+    public void creationParams_colorModeDark_appliesHardwareLayer() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("colorMode", "dark");
+        params.put("backgroundColor", 0xFFFEF7FF);
+        FlutterPDFView pdf = newView(params);
+
+        View view = pdf.getView();
+        assertEquals(View.LAYER_TYPE_HARDWARE, view.getLayerType());
+        ColorDrawable bg = (ColorDrawable) view.getBackground();
+        int expected = PdfColorMatrix.transformColor(0xFFFEF7FF, PdfColorMatrix.LUMINANCE_INVERT);
+        assertEquals(expected, bg.getColor());
+    }
+
+    @Test
+    public void updateSettings_unknownKey_stillThrows() {
+        FlutterPDFView pdf = newView(new HashMap<>());
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("notARealSetting", true);
+        assertThrows(IllegalArgumentException.class, () ->
+                pdf.onMethodCall(
+                        new MethodCall("updateSettings", settings),
+                        mock(MethodChannel.Result.class)
+                )
+        );
+    }
+}

--- a/android/src/test/java/io/endigo/plugins/pdfviewflutter/PdfColorMatrixTest.java
+++ b/android/src/test/java/io/endigo/plugins/pdfviewflutter/PdfColorMatrixTest.java
@@ -1,0 +1,117 @@
+package io.endigo.plugins.pdfviewflutter;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Plain JUnit tests for {@link PdfColorMatrix} (no Android framework / Robolectric).
+ */
+public class PdfColorMatrixTest {
+
+    private static final float[] M = PdfColorMatrix.LUMINANCE_INVERT;
+
+    @Test
+    public void luminanceInvert_hasExpectedLayout() {
+        assertEquals(20, M.length);
+        // Row 0 linear coeffs ≈ 1/3, -2/3, -2/3 and bias 255
+        assertEquals(1f / 3f, M[0], 1e-6f);
+        assertEquals(-2f / 3f, M[1], 1e-6f);
+        assertEquals(-2f / 3f, M[2], 1e-6f);
+        assertEquals(0f, M[3], 0f);
+        assertEquals(255f, M[4], 0f);
+        // Alpha row is identity
+        assertArrayEquals(
+                new float[]{0f, 0f, 0f, 1f, 0f},
+                new float[]{M[15], M[16], M[17], M[18], M[19]},
+                0f
+        );
+    }
+
+    @Test
+    public void white_becomesBlack() {
+        assertEquals(0xFF000000, PdfColorMatrix.transformColor(0xFFFFFFFF, M));
+    }
+
+    @Test
+    public void black_becomesWhite() {
+        assertEquals(0xFFFFFFFF, PdfColorMatrix.transformColor(0xFF000000, M));
+    }
+
+    @Test
+    public void midGrey_isInvolution() {
+        assertInvolution(0xFF808080);
+    }
+
+    @Test
+    public void nearWhite_becomesNearBlack() {
+        // Example Material surface (0xFEF7FF): may clip slightly so exact
+        // involution is not required; it must still land in the dark range.
+        int out = PdfColorMatrix.transformColor(0xFFFEF7FF, M);
+        int r = (out >> 16) & 0xFF;
+        int g = (out >> 8) & 0xFF;
+        int b = out & 0xFF;
+        assertTrue("expected dark result, got r=" + r + " g=" + g + " b=" + b,
+                r < 32 && g < 32 && b < 32);
+    }
+
+    @Test
+    public void nearBlack_isInvolution() {
+        // Low-saturation greys (and near-blacks) stay in range → exact involution.
+        assertInvolution(0xFF121212);
+    }
+
+    @Test
+    public void realisticGutter_surfaceGrey_isInvolution() {
+        // Non-saturated gutters recover exactly under M∘M.
+        assertInvolution(0xFFF5F5F5);
+        assertInvolution(0xFFE8E8E8);
+        assertInvolution(0xFF1C1B1F);
+    }
+
+    @Test
+    public void red_staysReddish_notCyan() {
+        // Luminance invert of pure red stays in the red family (R dominant),
+        // unlike a naive channel invert which yields cyan.
+        int out = PdfColorMatrix.transformColor(0xFFFF0000, M);
+        int r = (out >> 16) & 0xFF;
+        int g = (out >> 8) & 0xFF;
+        int b = out & 0xFF;
+        assertTrue("R should dominate after luminance invert of red, got r=" + r + " g=" + g + " b=" + b,
+                r > g && r > b);
+        assertTrue("G and B channels should match for pure red input", g == b);
+    }
+
+    @Test
+    public void doubleApplication_recoversGreys() {
+        // Greys lie on the eigenspace where involution is exact (no clipping).
+        int[] greys = {
+                0xFF000000, 0xFF111111, 0xFF404040, 0xFF808080,
+                0xFFC0C0C0, 0xFFEEEEEE, 0xFFFFFFFF
+        };
+        for (int c : greys) {
+            assertInvolution(c);
+        }
+    }
+
+    @Test
+    public void defaultMatrix_overload_usesLuminanceInvert() {
+        assertEquals(
+                PdfColorMatrix.transformColor(0xFF808080, M),
+                PdfColorMatrix.transformColor(0xFF808080)
+        );
+    }
+
+    private static void assertInvolution(int argb) {
+        int once = PdfColorMatrix.transformColor(argb, M);
+        int twice = PdfColorMatrix.transformColor(once, M);
+        assertEquals(
+                String.format("M(M(0x%08X)) should recover original, got 0x%08X via 0x%08X",
+                        argb, twice, once),
+                argb,
+                twice
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Adds proper dark/light color theming on Android for `flutter_pdfview`, replacing the hard `setNightMode()` invert with a **luminance-preserving** color matrix on a hardware layer.

- New `PdfColorMatrix` with involution matrix (hue-preserving invert)
- `FlutterPDFView` accepts `colorMode` + `backgroundColor` in `updateSettings`
- Single `applyColorTheme()` after recording both keys (no double `loadPages`)
- Gutter uses `M(bg)` so it renders as the requested color under the layer
- Screenshots use `saveLayer` so captures match on-screen theme
- Unit tests for matrix math and settings acceptance

## Stack
1. **This PR** (Android) ← `migrate/kotlin-swift`
2. iOS themed pages + real `onUpdateSettings`
3. Dart `PdfColorMode` API + example

## Test plan
- [x] `./gradlew :flutter_pdfview:testDebugUnitTest` (all pass, including new color mode tests)
- [ ] Device: toggle light/dark, confirm pages + gutter, photos stay recognizable