### PR TITLE
feat(ios): colorMode via FPVThemedPage + real onUpdateSettings

### DIFF
--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FPVThemedPage.swift
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FPVThemedPage.swift
@@ -1,0 +1,178 @@
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import PDFKit
+import UIKit
+
+// MARK: - Color mode
+
+/// How page content is themed. Mirrors Dart's `PdfColorMode`.
+enum FPVColorMode {
+    case light
+    case dark
+    /// Follow the app's theme. Dart resolves this before it reaches the native
+    /// side; it is only handled here so a caller that sends it verbatim gets the
+    /// system appearance rather than an unconditional light page.
+    case system
+}
+
+// MARK: - The color transform
+
+/// The luminance-inverting color matrix shared with the Android implementation.
+///
+/// ```
+///  0.333  -0.667  -0.667   bias +1
+/// -0.667   0.333  -0.667   bias +1
+/// -0.667  -0.667   0.333   bias +1
+/// ```
+///
+/// It inverts lightness while preserving hue: white→black, black→white, but a
+/// saturated red (1, 0, 0) becomes (1, 0.333, 0.333) — still red — where a naive
+/// `1 - v` inversion would flip it to cyan and turn photos into negatives.
+///
+/// The matrix is an involution (`M(M(v)) == v`), which is what lets Android
+/// compensate its inverted gutter with the same matrix. iOS transforms only page
+/// content, so the gutter is set to the requested color directly.
+///
+/// Kept as a constant rather than inlined so a future sepia / soft-dark mode is a
+/// new constant instead of an API change.
+enum FPVColorMatrix {
+    private static let diagonal: CGFloat = 0.333
+    private static let offDiagonal: CGFloat = -0.667
+
+    static let luminanceInvertR = CIVector(x: diagonal, y: offDiagonal, z: offDiagonal, w: 0)
+    static let luminanceInvertG = CIVector(x: offDiagonal, y: diagonal, z: offDiagonal, w: 0)
+    static let luminanceInvertB = CIVector(x: offDiagonal, y: offDiagonal, z: diagonal, w: 0)
+    /// Alpha passes through untouched.
+    static let luminanceInvertA = CIVector(x: 0, y: 0, z: 0, w: 1)
+    static let luminanceInvertBias = CIVector(x: 1, y: 1, z: 1, w: 0)
+}
+
+// MARK: - Themed page
+
+/// A `PDFPage` that renders itself through ``FPVColorMatrix`` in dark mode.
+///
+/// `FlutterPDFView` installs this class **unconditionally** through
+/// `PDFDocumentDelegate.classForPage()`, in every color mode: the mode is read at
+/// draw time, so flipping it never requires re-instantiating pages. In light mode
+/// this is exactly `super.draw`.
+///
+/// The mode is read through the document's delegate rather than a static or a
+/// per-page flag — iterating the document to push a flag onto every page would
+/// instantiate every page of a large document.
+final class FPVThemedPage: PDFPage {
+    /// Ceiling on the offscreen bitmap for a single draw call (16 Mpx ≈ 64 MB).
+    ///
+    /// `PDFView` tiles zoomed pages, so a tile is normally at most a few
+    /// screenfuls; anything above this is pathological and renders untransformed
+    /// rather than risking the allocation.
+    private static let maxOffscreenPixels = 16 * 1024 * 1024
+
+    /// Shared because `CIContext` creation is expensive and it is thread-safe —
+    /// PDFKit renders pages off the main thread.
+    private static let ciContext: CIContext = {
+        // Apply the matrix to sRGB-encoded values, which is what the coefficients
+        // were authored against and what Android's ColorMatrixColorFilter does.
+        // CoreImage would otherwise convert to its linear working space first and
+        // produce a different (and no longer involutive) result.
+        let space = CGColorSpaceCreateDeviceRGB()
+        return CIContext(options: [
+            .workingColorSpace: space,
+            .outputColorSpace: space,
+            .cacheIntermediates: false,
+        ])
+    }()
+
+    override func draw(with box: PDFDisplayBox, to context: CGContext) {
+        guard let owner = document?.delegate as? FlutterPDFView, owner.isDarkMode else {
+            super.draw(with: box, to: context)
+            return
+        }
+
+        var didDrawThemed = false
+        catchingNSException {
+            didDrawThemed = drawInverted(with: box, to: context)
+        } onException: { error in
+            NSLog("Warning: Dark-mode page render failed: %@", error.pdfExceptionReason)
+            didDrawThemed = false
+        }
+
+        if !didDrawThemed {
+            // Nothing has been written to `context` yet on any failure path, so
+            // the plain render is still safe to run.
+            super.draw(with: box, to: context)
+        }
+    }
+
+    /// Renders `super.draw` into an offscreen bitmap, runs the color matrix over
+    /// it and draws the result into `context`.
+    ///
+    /// - Returns: `true` when the themed image was drawn, `false` when the caller
+    ///   should fall back to a plain `super.draw`.
+    private func drawInverted(with box: PDFDisplayBox, to context: CGContext) -> Bool {
+        // Size to the clip, not to the page: `PDFView` tiles large or zoomed pages
+        // and calls this once per tile, so a page-sized offscreen would scale with
+        // the zoom factor.
+        let clipRect = context.boundingBoxOfClipPath
+        guard clipRect.width > 0, clipRect.height > 0 else { return false }
+
+        // The CTM maps user space to the destination's backing store, so it
+        // already carries the zoom and the screen scale.
+        let ctm = context.ctm
+        guard (ctm.a * ctm.d - ctm.b * ctm.c) != 0 else { return false }
+
+        let deviceRect = clipRect.applying(ctm).integral
+        let width = Int(deviceRect.width)
+        let height = Int(deviceRect.height)
+        guard width > 0, height > 0, width * height <= Self.maxOffscreenPixels else {
+            return false
+        }
+
+        guard let offscreen = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                | CGBitmapInfo.byteOrder32Little.rawValue
+        ) else { return false }
+
+        // `PDFPage.draw` does not clear its background — `PDFView.drawPage` erases
+        // to white before calling it. Without the prefill the page margins would
+        // stay transparent black and the matrix would render them white.
+        offscreen.setFillColor(UIColor.white.cgColor)
+        offscreen.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        // Reproduce the destination's user→device mapping, shifted so the tile's
+        // device origin lands on the offscreen's origin.
+        offscreen.translateBy(x: -deviceRect.origin.x, y: -deviceRect.origin.y)
+        offscreen.concatenate(ctm)
+        super.draw(with: box, to: offscreen)
+
+        guard let rendered = offscreen.makeImage(),
+              let inverted = Self.applyLuminanceInversion(to: rendered)
+        else { return false }
+
+        context.saveGState()
+        // The tile was rasterised in device space, so undo the CTM and blit it
+        // back 1:1 instead of re-deriving the rect in user space.
+        context.concatenate(ctm.inverted())
+        context.interpolationQuality = .none
+        context.draw(inverted, in: deviceRect)
+        context.restoreGState()
+        return true
+    }
+
+    private static func applyLuminanceInversion(to image: CGImage) -> CGImage? {
+        let filter = CIFilter.colorMatrix()
+        filter.inputImage = CIImage(cgImage: image)
+        filter.rVector = FPVColorMatrix.luminanceInvertR
+        filter.gVector = FPVColorMatrix.luminanceInvertG
+        filter.bVector = FPVColorMatrix.luminanceInvertB
+        filter.aVector = FPVColorMatrix.luminanceInvertA
+        filter.biasVector = FPVColorMatrix.luminanceInvertBias
+        guard let output = filter.outputImage else { return nil }
+        return ciContext.createCGImage(output, from: output.extent)
+    }
+}

--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
@@ -17,7 +17,10 @@ import flutter_pdfview_objc
 ///
 /// Swift has no `@try`/`@catch`; every call site below mirrors one that the
 /// Objective-C implementation guarded the same way.
-private func catchingNSException(_ body: () -> Void, onException: (NSError) -> Void) {
+///
+/// Internal rather than file-private so `FPVThemedPage` can guard its own PDFKit
+/// calls the same way.
+func catchingNSException(_ body: () -> Void, onException: (NSError) -> Void) {
     do {
         try FPVExceptionCatcher.catchException(body)
     } catch {
@@ -25,7 +28,7 @@ private func catchingNSException(_ body: () -> Void, onException: (NSError) -> V
     }
 }
 
-private extension NSError {
+extension NSError {
     /// Equivalent of `exception.reason`, including the `"(null)"` that
     /// `NSLog(@"%@", exception.reason)` printed when there was none.
     var pdfExceptionReason: String {
@@ -196,7 +199,7 @@ final class PDFViewController: NSObject, FlutterPlatformView, PDFViewDelegate {
 // MARK: - The view itself
 
 @objc(FLTPDFView)
-final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
+final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate, PDFDocumentDelegate,
     UIGestureRecognizerDelegate, UIScrollViewDelegate
 {
     /// How pages are scaled to the viewport (mirrors Dart [FitPolicy]).
@@ -234,6 +237,17 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
     private var lastFitScale: CGFloat = 0
     /// Whether we have successfully applied an initial fit at a real size.
     private var hasAppliedInitialFit = false
+    /// Resolved color mode, read by `FPVThemedPage` on every page draw.
+    ///
+    /// Stored rather than derived on demand so the page never has to touch
+    /// `traitCollection` — PDFKit renders pages off the main thread.
+    private(set) var isDarkMode = false
+    /// Set while `rerenderPreservingPosition()` swaps the document out and back,
+    /// so the page churn that causes is not reported to Dart as a page change.
+    private var isRerendering = false
+    /// Last `enableSwipe` pushed through `updateSettings`, re-applied after a
+    /// re-render. `nil` until Dart updates it.
+    private var swipeEnabledOverride: Bool?
 
     init(frame: CGRect, arguments args: Any?, controller: PDFViewController) {
         self.controller = controller
@@ -307,6 +321,7 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
         let pageFling = args?.bool("pageFling") ?? false
         let enableSwipe = args?.bool("enableSwipe") ?? false
         preventLinkNavigation = args?.bool("preventLinkNavigation") ?? false
+        setColorMode(Self.colorMode(fromSettings: args) ?? .light)
 
         var defaultPageIndex = args?.integer("defaultPage") ?? 0
 
@@ -331,6 +346,11 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
             }
             return
         }
+
+        // Pages are instantiated lazily on first access, so the delegate that
+        // supplies `FPVThemedPage` has to be in place before anything — including
+        // `pdfView.document` below — touches a page.
+        document.delegate = self
 
         pdfView.autoresizesSubviews = true
         pdfView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -885,7 +905,69 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
         result(NSNumber(value: true))
     }
 
-    func onUpdateSettings(_: FlutterMethodCall, result: FlutterResult) {
+    /// Applies the settings Dart pushes when a `PDFView` is rebuilt with
+    /// different values.
+    ///
+    /// Until 1.5.0 this was a no-op stub and every key was silently dropped, so
+    /// apps that relied on updates not taking effect will now see them applied.
+    /// Keys iOS cannot honour (`pageFling`, `pageSnap`) and keys it does not know
+    /// are accepted and ignored — never rejected — because a `FlutterError` here
+    /// surfaces as an unhandled exception in the app's build phase.
+    func onUpdateSettings(_ call: FlutterMethodCall, result: FlutterResult) {
+        guard let settings = call.arguments as? [String: Any] else {
+            result(nil)
+            return
+        }
+
+        // `colorMode` and `backgroundColor` arrive in the same map and both want
+        // the view repainted, so state is recorded first and the (expensive)
+        // re-render runs once at the end.
+        var needsRerender = false
+
+        if settings.keys.contains("colorMode") || settings.keys.contains("nightMode"),
+           let mode = Self.colorMode(fromSettings: settings)
+        {
+            needsRerender = setColorMode(mode)
+        }
+
+        if settings.keys.contains("backgroundColor"), let color = settings.color("backgroundColor") {
+            // Only pages go through the color matrix on iOS, so the gutter is set
+            // to exactly what Dart asked for. A present-but-null value keeps the
+            // current color (documented: clearing back to null is not supported).
+            pdfView.backgroundColor = color
+            backgroundColor = color
+        }
+
+        if settings.keys.contains("preventLinkNavigation") {
+            preventLinkNavigation = settings.bool("preventLinkNavigation")
+        }
+
+        if settings.keys.contains("enableSwipe") {
+            swipeEnabledOverride = settings.bool("enableSwipe")
+            applySwipeEnabled()
+        }
+
+        if settings.keys.contains("minZoom") || settings.keys.contains("maxZoom") {
+            // Either key can arrive on its own; keep the other multiplier.
+            var minZoom = minScaleFactor
+            var maxZoom = maxScaleFactor
+            if let requested = settings.number("minZoom")?.doubleValue, requested > 0 {
+                minZoom = CGFloat(requested)
+            }
+            if let requested = settings.number("maxZoom")?.doubleValue, requested > 0 {
+                maxZoom = CGFloat(requested)
+            }
+            // Unlike setZoomLimits this cannot report INVALID_ARGS, so an
+            // inverted pair is dropped rather than applied.
+            if minZoom > 0, maxZoom >= minZoom {
+                applyZoomLimits(minZoom: minZoom, maxZoom: maxZoom)
+            }
+        }
+
+        if needsRerender {
+            rerenderPreservingPosition()
+        }
+
         result(nil)
     }
 
@@ -905,6 +987,13 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
             )
             return
         }
+        applyZoomLimits(minZoom: minZoom, maxZoom: maxZoom)
+        result(NSNumber(value: true))
+    }
+
+    /// Stores the zoom multipliers and derives PDFKit's absolute limits from the
+    /// current fit scale. Callers are responsible for validating the pair.
+    private func applyZoomLimits(minZoom: CGFloat, maxZoom: CGFloat) {
         // Persist the multipliers — applyLayoutUpdates re-derives PDFKit's
         // min/max from these on every layout pass, so writing only the PDFKit
         // values would be reverted by the next rotation/resize.
@@ -923,12 +1012,117 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
             pdfView.minScaleFactor = minScale
             pdfView.maxScaleFactor = max(maxScale, minScale)
         }
-        result(NSNumber(value: true))
+    }
+
+    private func applySwipeEnabled() {
+        guard let enabled = swipeEnabledOverride else { return }
+        // The scroll view is discovered asynchronously after load, so fall back to
+        // a fresh lookup if the update lands first.
+        let target = scrollView ?? findScrollView(pdfView)
+        target?.isScrollEnabled = enabled
+    }
+
+    // MARK: - Color mode
+
+    /// Parses `colorMode` (`"PdfColorMode.dark"`, `"dark"`, …), falling back to
+    /// the deprecated `nightMode` boolean. `nil` when neither key is usable.
+    private static func colorMode(fromSettings settings: [String: Any]?) -> FPVColorMode? {
+        if let raw = settings?["colorMode"] as? String {
+            // Accepts both `enum.toString()` and `enum.name` spellings.
+            let token = (raw.split(separator: ".").last.map(String.init) ?? raw).lowercased()
+            switch token {
+            case "light":
+                return .light
+            case "dark":
+                return .dark
+            case "system":
+                return .system
+            default:
+                break
+            }
+        }
+        if let nightMode = settings?.number("nightMode")?.boolValue {
+            return nightMode ? .dark : .light
+        }
+        return nil
+    }
+
+    /// - Returns: `true` when the resolved mode actually changed, i.e. when the
+    ///   caller has to force a re-render.
+    @discardableResult
+    private func setColorMode(_ mode: FPVColorMode) -> Bool {
+        let resolved: Bool
+        switch mode {
+        case .light:
+            resolved = false
+        case .dark:
+            resolved = true
+        case .system:
+            // Dart normally resolves `system` from the app's Theme; this is only
+            // the fallback for a caller that passes it through verbatim.
+            resolved = traitCollection.userInterfaceStyle == .dark
+        }
+        guard resolved != isDarkMode else { return false }
+        isDarkMode = resolved
+        return true
+    }
+
+    /// Forces every visible page through `FPVThemedPage.draw` again without
+    /// losing the reader's place.
+    ///
+    /// PDFKit caches rendered pages and exposes no cache-flush API, so the
+    /// document has to be handed back to the view — the same primitive `reload`
+    /// uses. Unlike `reload` this restores the page, scale and scroll offset, and
+    /// leaves the #150 fit state (`hasAppliedInitialFit` / `lastFitScale` /
+    /// `lastLayoutSize`) untouched so the next layout pass does not re-fit.
+    private func rerenderPreservingPosition() {
+        guard let document = pdfView.document else { return }
+
+        let savedScale = pdfView.scaleFactor
+        let savedDestination = pdfView.currentDestination
+        let savedOffset = scrollView?.contentOffset
+        let savedPage = pdfView.currentPage
+
+        isRerendering = true
+        catchingNSException {
+            pdfView.document = nil
+            pdfView.document = document
+
+            // Reassigning the document resets PDFKit's own min/max scale factors,
+            // so re-derive them before restoring the scale — otherwise the restore
+            // is clamped to PDFKit's defaults.
+            applyZoomLimits(minZoom: minScaleFactor, maxZoom: maxScaleFactor)
+
+            if savedScale.isFinite, savedScale > 0 {
+                pdfView.scaleFactor = savedScale
+            }
+            if let savedDestination {
+                pdfView.go(to: savedDestination)
+            } else if let savedPage {
+                pdfView.go(to: savedPage)
+            }
+            // The destination restores the page and the point within it; the raw
+            // offset pins the remaining sub-page scroll. PDFKit keeps the same
+            // scroll view across a document swap, so the cached reference (and the
+            // contentOffset observation on it) stays valid.
+            if let savedOffset, let scrollView {
+                scrollView.setContentOffset(savedOffset, animated: false)
+            }
+            applySwipeEnabled()
+        } onException: { error in
+            NSLog("Warning: Failed to re-render after settings update: %@", error.pdfExceptionReason)
+        }
+        isRerendering = false
     }
 
     // MARK: - Callbacks
 
     @objc private func handlePageChanged(_: Notification) {
+        // Swapping the document out and back fires this for the intermediate
+        // state; the page the user is on has not actually changed.
+        if isRerendering {
+            return
+        }
         guard let document = pdfView.document, let currentPage = pdfView.currentPage else {
             return
         }
@@ -967,6 +1161,14 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
                 "pdfScale": NSNumber(value: Float(pdfView.scaleFactor)),
             ]
         )
+    }
+
+    // MARK: - PDFDocumentDelegate
+
+    /// Installed unconditionally, in every color mode: `FPVThemedPage` reads the
+    /// mode at draw time, so a theme change never has to re-instantiate pages.
+    @objc func classForPage() -> AnyClass {
+        FPVThemedPage.self
     }
 
     // MARK: - PDFViewDelegate


### PR DESCRIPTION
## Summary
iOS dark/light theming + fixes the long-standing no-op `onUpdateSettings`.

- New `FPVThemedPage` (`PDFPage` subclass) with `CIColorMatrix` luminance invert
- `PDFDocumentDelegate.classForPage()` installed unconditionally; mode read at draw time
- Real `onUpdateSettings` for `colorMode`, `backgroundColor`, `preventLinkNavigation`, `enableSwipe`, `minZoom`/`maxZoom` (accept-and-ignore `pageFling`/`pageSnap`)
- Position-preserving re-render on theme toggle (keeps page/scale/offset + #150 fit state)
- Stacks on Android colorMode PR

## Stack
1. Android colorMode (base)
2. **This PR** (iOS)
3. Dart `PdfColorMode` API + example

## Test plan
- [x] `flutter build ios --debug --no-codesign` (verified by worker)
- [ ] Device: theme toggle preserves scroll/zoom; scroll large PDF in dark mode for CIFilter jank

**Note:** Making `onUpdateSettings` live changes behavior for keys that were previously silently dropped.