### PR TITLE
feat(dart): PdfColorMode API with Theme-driven system mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## 1.5.0-beta.1
 
+- **Dart**: add `PdfColorMode` (`light` / `dark` / `system`) and `PDFView.colorMode` (default
+  `system`). `system` resolves from the app `Theme` brightness (or platform brightness when no
+  `Theme` ancestor is present) and is sent to native as `"light"` / `"dark"`. Dark mode uses a
+  luminance-preserving inversion on both platforms so photos keep their hue.
+- **Deprecate** `nightMode` (still honored: `nightMode: true` with default `colorMode` maps to
+  `dark`; an explicit `colorMode` always wins). Annotate the field and constructor formal so
+  callers see the analyzer warning.
+- Runtime updates now include `colorMode` and `backgroundColor` in the settings diff (without
+  remounting the platform view). Setting `backgroundColor` back to `null` after a non-null value
+  leaves the previous color on screen.
+- **Example**: `MaterialApp` `theme` / `darkTheme` / `themeMode` with an AppBar toggle; PDF gutter
+  uses `colorScheme.surface`; removed the hardcoded `nightMode: true` + light gutter pair.
 - **Android**: migrate the plugin implementation from Java to Kotlin (KGP 2.0.0, JVM target 17).
   Behavior verified by the existing 64-test native suite running against the Kotlin sources unchanged
 - **iOS**: migrate the plugin implementation from Objective-C to Swift 5.9. The registered
@@ -8,7 +20,6 @@
   Swift Package Manager and CocoaPods (`pod lib lint`, dynamic + static)
 - Fix a platform-view remount race: late creation callbacks from a disposed or remounted view can no
   longer complete the new controller with a stale instance
-- No public Dart API changes
 
 ## 1.4.5-beta.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 ## 1.5.0-beta.1
 
+- Fix [#215](https://github.com/endigo/flutter_pdfview/issues/215): night mode used a naive
+  channel invert that turned photos into negatives. Dark mode now uses a luminance-preserving
+  inversion on both platforms so white↔black while hue is kept.
+- Fix [#138](https://github.com/endigo/flutter_pdfview/issues/138): iOS had no night mode. Dark
+  mode is implemented via `FPVThemedPage` (PDFKit page draw through the same matrix).
+- **Android**: apply `colorMode` via a hardware-layer `ColorMatrixColorFilter` (replacing
+  AndroidPdfViewer `setNightMode`); gutters use `M(backgroundColor)` so the layer shows the
+  color Dart requested; screenshots use `saveLayer` so captures match the on-screen theme.
 - **Dart**: add `PdfColorMode` (`light` / `dark` / `system`) and `PDFView.colorMode` (default
   `system`). `system` resolves from the app `Theme` brightness (or platform brightness when no
-  `Theme` ancestor is present) and is sent to native as `"light"` / `"dark"`. Dark mode uses a
-  luminance-preserving inversion on both platforms so photos keep their hue.
+  `Theme` ancestor is present) and is sent to native as `"light"` / `"dark"`.
 - **Deprecate** `nightMode` (still honored: `nightMode: true` with default `colorMode` maps to
   `dark`; an explicit `colorMode` always wins). Annotate the field and constructor formal so
   callers see the analyzer warning.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 | enableSwipe           |   ✅    | ✅  |      `true`       |
 | swipeHorizontal       |   ✅    | ✅  |      `false`      |
 | password              |   ✅    | ✅  |      `null`       |
-| nightMode             |   ✅    | ❌  |      `false`      |
+| colorMode             |   ✅    | ✅  | `PdfColorMode.system` |
+| nightMode*            |   ✅    | ✅  |      `false`      |
 | autoSpacing*          |   ✅    | ✅  |      `true`       |
 | pageFling             |   ✅    | ✅  |      `true`       |
 | pageSnap              |   ✅    | ❌  |      `true`       |
@@ -69,6 +70,9 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 | showScrollIndicators* |   ✅    | ✅  |      `false`      |
 
 Notes:
+- `colorMode` themes page content and the gutter on both platforms. Values: `PdfColorMode.light`, `PdfColorMode.dark`, `PdfColorMode.system` (default). `system` follows the app `Theme` brightness (or platform brightness when no `Theme` is present) and is resolved in Dart before being sent to the native view. Dark mode uses a luminance-preserving inversion (hue kept; photos do not become pure negatives). Live updates apply without remounting the platform view.
+- `nightMode` is **deprecated**. Prefer `colorMode`. When `colorMode` is left at `system` and `nightMode: true`, the resolved mode is `dark`. An explicit `colorMode` always wins.
+- `backgroundColor` can be updated at runtime together with `colorMode`. Setting it back to `null` after a non-null value leaves the previous color on screen.
 - `showScrollIndicators` is ignored on iOS while horizontal page-flipping is active (`pageFling: true` together with `swipeHorizontal: true`).
 - `autoSpacing` only adds gaps between pages. It does not change initial zoom or `fitPolicy` (fixed in [#150](https://github.com/endigo/flutter_pdfview/issues/150)).
 
@@ -118,7 +122,8 @@ PDFView(
   autoSpacing: false,
   pageFling: false,
   showScrollIndicators: true,
-  backgroundColor: Colors.grey,
+  colorMode: PdfColorMode.system, // follows Theme brightness
+  backgroundColor: Theme.of(context).colorScheme.surface,
   onRender: (_pages) {
     setState(() {
       pages = _pages;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,6 +31,7 @@ class _MyAppState extends State<MyApp> {
   String landscapePathPdf = '';
   String remotePDFpath = '';
   String corruptedPathPDF = '';
+  ThemeMode _themeMode = ThemeMode.system;
 
   @override
   void initState() {
@@ -59,6 +60,30 @@ class _MyAppState extends State<MyApp> {
         remotePDFpath = f.path;
       });
     });
+  }
+
+  void _toggleThemeMode() {
+    setState(() {
+      switch (_themeMode) {
+        case ThemeMode.light:
+          _themeMode = ThemeMode.dark;
+        case ThemeMode.dark:
+          _themeMode = ThemeMode.system;
+        case ThemeMode.system:
+          _themeMode = ThemeMode.light;
+      }
+    });
+  }
+
+  IconData get _themeModeIcon {
+    switch (_themeMode) {
+      case ThemeMode.light:
+        return Icons.light_mode;
+      case ThemeMode.dark:
+        return Icons.dark_mode;
+      case ThemeMode.system:
+        return Icons.brightness_auto;
+    }
   }
 
   Future<File> createFileOfPdfUrl() async {
@@ -109,8 +134,29 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Flutter PDF View',
       debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      darkTheme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.deepPurple,
+          brightness: Brightness.dark,
+        ),
+        useMaterial3: true,
+      ),
+      themeMode: _themeMode,
       home: Scaffold(
-        appBar: AppBar(title: const Text('Plugin example app')),
+        appBar: AppBar(
+          title: const Text('Plugin example app'),
+          actions: <Widget>[
+            IconButton(
+              tooltip: 'Theme: ${_themeMode.name}',
+              icon: Icon(_themeModeIcon),
+              onPressed: _toggleThemeMode,
+            ),
+          ],
+        ),
         body: Center(
           child: Builder(
             builder: (BuildContext context) {
@@ -203,7 +249,7 @@ class PDFScreen extends StatefulWidget {
   State<PDFScreen> createState() => _PDFScreenState();
 }
 
-class _PDFScreenState extends State<PDFScreen> with WidgetsBindingObserver {
+class _PDFScreenState extends State<PDFScreen> {
   final Completer<PDFViewController> _controller = Completer<PDFViewController>();
   int? _pages = 0;
   int? _currentPage = 0;
@@ -216,6 +262,8 @@ class _PDFScreenState extends State<PDFScreen> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    final Color surface = Theme.of(context).colorScheme.surface;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Document'),
@@ -238,8 +286,9 @@ class _PDFScreenState extends State<PDFScreen> with WidgetsBindingObserver {
             defaultPage: _currentPage!,
             fitPolicy: FitPolicy.BOTH,
             preventLinkNavigation: false, // if set to true the link is handled in flutter
-            backgroundColor: const Color(0xFFFEF7FF),
-            nightMode: true,
+            // Follows app Theme; page content + gutter update live without remount.
+            colorMode: PdfColorMode.system,
+            backgroundColor: surface,
             maxZoom: 4.0,
             minZoom: 1.0,
             onRender: (pages) {

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -20,6 +20,25 @@ void main() {
       expect(find.text('Remote PDF'), findsOneWidget);
       expect(find.text('Open PDF (iPad Safe Mode)'), findsOneWidget);
       expect(find.text('Open Corrupted PDF'), findsOneWidget);
+      // Theme toggle lives in the home AppBar.
+      expect(find.byTooltip('Theme: system'), findsOneWidget);
+    });
+
+    testWidgets('theme toggle cycles light → dark → system', (tester) async {
+      await tester.pumpWidget(const MyApp(loadDocuments: false));
+      await tester.pump();
+
+      await tester.tap(find.byTooltip('Theme: system'));
+      await tester.pump();
+      expect(find.byTooltip('Theme: light'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Theme: light'));
+      await tester.pump();
+      expect(find.byTooltip('Theme: dark'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Theme: dark'));
+      await tester.pump();
+      expect(find.byTooltip('Theme: system'), findsOneWidget);
     });
 
     testWidgets('Open PDF is a tappable TextButton', (tester) async {

--- a/lib/flutter_pdfview.dart
+++ b/lib/flutter_pdfview.dart
@@ -26,6 +26,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart' show Theme;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/lib/src/pdf_view.dart
+++ b/lib/src/pdf_view.dart
@@ -314,10 +314,7 @@ class _PDFViewState extends State<PDFView> {
       if (!mounted) {
         return;
       }
-      controller._updateWidget(
-        widget,
-        resolvedColorMode: _resolveColorMode(context),
-      );
+      controller._updateWidget(widget, resolvedColorMode: _resolveColorMode(context));
     });
   }
 
@@ -394,7 +391,11 @@ class _PDFViewState extends State<PDFView> {
             )
             ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
             ..addOnPlatformViewCreatedListener((int id) {
-              _onPlatformViewCreated(id, generation: generation, resolvedColorMode: resolvedColorMode);
+              _onPlatformViewCreated(
+                id,
+                generation: generation,
+                resolvedColorMode: resolvedColorMode,
+              );
             })
             ..create();
         },
@@ -467,10 +468,7 @@ class _PDFViewState extends State<PDFView> {
 class _CreationParams {
   _CreationParams({this.filePath, this.pdfData, this.settings});
 
-  static _CreationParams fromWidget(
-    PDFView widget, {
-    required PdfColorMode resolvedColorMode,
-  }) {
+  static _CreationParams fromWidget(PDFView widget, {required PdfColorMode resolvedColorMode}) {
     return _CreationParams(
       filePath: widget.filePath,
       pdfData: widget.pdfData,

--- a/lib/src/pdf_view.dart
+++ b/lib/src/pdf_view.dart
@@ -32,7 +32,12 @@ class PDFView extends StatefulWidget {
     this.swipeHorizontal = false,
     this.showScrollIndicators = false,
     this.password,
+    @Deprecated(
+      'Use colorMode instead. nightMode: true maps to PdfColorMode.dark when '
+      'colorMode is left at PdfColorMode.system.',
+    )
     this.nightMode = false,
+    this.colorMode = PdfColorMode.system,
     this.autoSpacing = true,
     this.pageFling = true,
     this.pageSnap = true,
@@ -117,7 +122,22 @@ class PDFView extends StatefulWidget {
 
   /// Indicates whether or not the PDF viewer is in night mode. If set to true, the viewer is in
   /// night mode.
+  ///
+  /// Deprecated: use [colorMode] instead. When [colorMode] is [PdfColorMode.system] (the default)
+  /// and this is `true`, the resolved mode is [PdfColorMode.dark]. An explicit [colorMode] always
+  /// wins.
+  @Deprecated(
+    'Use colorMode instead. nightMode: true maps to PdfColorMode.dark when '
+    'colorMode is left at PdfColorMode.system.',
+  )
   final bool nightMode;
+
+  /// Color theme for page content and the gutter.
+  ///
+  /// Defaults to [PdfColorMode.system], which follows the app [Theme] brightness
+  /// (or [MediaQuery] platform brightness when no [Theme] ancestor exists).
+  /// Resolved in Dart to `light` or `dark` before being sent to the native view.
+  final PdfColorMode colorMode;
 
   /// Whether the viewer adds spacing (page breaks) between pages.
   ///
@@ -169,6 +189,10 @@ class PDFView extends StatefulWidget {
   final bool preventLinkNavigation;
 
   /// The background color drawn behind the document.
+  ///
+  /// When changed at runtime, the new color is pushed to the native view. Setting
+  /// this back to `null` after a non-null value leaves the previous color on
+  /// screen (the key is omitted from the settings diff).
   final Color? backgroundColor;
 
   /// Maximum zoom level. Defaults to 4.0.
@@ -192,6 +216,12 @@ class _PDFViewState extends State<PDFView> {
   /// first hash of each instance.
   Object? _pdfDataIdentity;
   int? _pdfDataDigest;
+
+  /// Whether the first [didChangeDependencies] has already been observed.
+  ///
+  /// The initial dependency pass must not schedule an [updateSettings] (there is
+  /// no controller yet, and creation params already carry the resolved mode).
+  bool _dependenciesReady = false;
 
   @override
   void initState() {
@@ -248,6 +278,49 @@ class _PDFViewState extends State<PDFView> {
     return _digestFor(a) != _digestFor(b);
   }
 
+  /// Resolves [PDFView.colorMode] to [PdfColorMode.light] or [PdfColorMode.dark].
+  ///
+  /// Called from [build] so [Theme]/[MediaQuery] dependencies stick. Also used
+  /// when pushing settings updates after [didUpdateWidget]/[didChangeDependencies].
+  PdfColorMode _resolveColorMode(BuildContext context) {
+    // Explicit colorMode always wins over the deprecated nightMode flag.
+    if (widget.colorMode != PdfColorMode.system) {
+      return widget.colorMode;
+    }
+    // Legacy: nightMode: true with the default colorMode ⇒ dark.
+    // ignore: deprecated_member_use_from_same_package
+    if (widget.nightMode) {
+      return PdfColorMode.dark;
+    }
+    // Prefer Theme when a Theme widget is actually an ancestor. Theme.of alone
+    // returns ThemeData.fallback() (light) when none is present, which would
+    // hide platform dark mode.
+    final Theme? themeWidget = context.findAncestorWidgetOfExactType<Theme>();
+    if (themeWidget != null) {
+      return Theme.of(context).brightness == Brightness.dark
+          ? PdfColorMode.dark
+          : PdfColorMode.light;
+    }
+    return MediaQuery.platformBrightnessOf(context) == Brightness.dark
+        ? PdfColorMode.dark
+        : PdfColorMode.light;
+  }
+
+  /// Coalesces didUpdateWidget + didChangeDependencies in one frame: both schedule
+  /// through the same [_controller] future and re-read [widget]/theme at callback
+  /// time so the first send carries the union and a second sees an empty diff.
+  void _scheduleSettingsUpdate() {
+    _controller.future.then((PDFViewController controller) {
+      if (!mounted) {
+        return;
+      }
+      controller._updateWidget(
+        widget,
+        resolvedColorMode: _resolveColorMode(context),
+      );
+    });
+  }
+
   void _remountPlatformView() {
     if (!mounted) {
       return;
@@ -267,7 +340,29 @@ class _PDFViewState extends State<PDFView> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Theme may change without didUpdateWidget (e.g. a const PDFView under a
+    // new ThemeMode). Skip the first pass — creation params already include the
+    // resolved mode from build().
+    if (_dependenciesReady) {
+      _scheduleSettingsUpdate();
+    } else {
+      _dependenciesReady = true;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    // Resolve here (not only in didChangeDependencies) so Theme/MediaQuery
+    // dependencies register correctly: StatefulElement.performRebuild clears
+    // _dependencies before build().
+    final PdfColorMode resolvedColorMode = _resolveColorMode(context);
+    final Map<String, dynamic> creationParams = _CreationParams.fromWidget(
+      widget,
+      resolvedColorMode: resolvedColorMode,
+    ).toMap();
+
     // Capture generation at build time so platform-view creation callbacks
     // from a previous mount cannot complete the current Completer.
     final int generation = _viewGeneration;
@@ -294,12 +389,12 @@ class _PDFViewState extends State<PDFView> {
               id: params.id,
               viewType: _viewType,
               layoutDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
-              creationParams: _CreationParams.fromWidget(widget).toMap(),
+              creationParams: creationParams,
               creationParamsCodec: const StandardMessageCodec(),
             )
             ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
             ..addOnPlatformViewCreatedListener((int id) {
-              _onPlatformViewCreated(id, generation: generation);
+              _onPlatformViewCreated(id, generation: generation, resolvedColorMode: resolvedColorMode);
             })
             ..create();
         },
@@ -309,18 +404,26 @@ class _PDFViewState extends State<PDFView> {
         key: viewKey,
         viewType: _viewType,
         onPlatformViewCreated: (int id) {
-          _onPlatformViewCreated(id, generation: generation);
+          _onPlatformViewCreated(id, generation: generation, resolvedColorMode: resolvedColorMode);
         },
         gestureRecognizers: widget.gestureRecognizers,
-        creationParams: _CreationParams.fromWidget(widget).toMap(),
+        creationParams: creationParams,
         creationParamsCodec: const StandardMessageCodec(),
       );
     }
     return Text('$defaultTargetPlatform is not yet supported by the pdfview_flutter plugin');
   }
 
-  void _onPlatformViewCreated(int id, {required int generation}) {
-    final PDFViewController controller = PDFViewController._(id, widget);
+  void _onPlatformViewCreated(
+    int id, {
+    required int generation,
+    required PdfColorMode resolvedColorMode,
+  }) {
+    final PDFViewController controller = PDFViewController._(
+      id,
+      widget,
+      resolvedColorMode: resolvedColorMode,
+    );
     // Ignore late callbacks from a remounted/disposed platform view so they
     // cannot complete the new Completer with a stale controller.
     if (!mounted || generation != _viewGeneration) {
@@ -346,7 +449,7 @@ class _PDFViewState extends State<PDFView> {
       _remountPlatformView();
       return;
     }
-    _controller.future.then((PDFViewController controller) => controller._updateWidget(widget));
+    _scheduleSettingsUpdate();
   }
 
   @override
@@ -364,11 +467,14 @@ class _PDFViewState extends State<PDFView> {
 class _CreationParams {
   _CreationParams({this.filePath, this.pdfData, this.settings});
 
-  static _CreationParams fromWidget(PDFView widget) {
+  static _CreationParams fromWidget(
+    PDFView widget, {
+    required PdfColorMode resolvedColorMode,
+  }) {
     return _CreationParams(
       filePath: widget.filePath,
       pdfData: widget.pdfData,
-      settings: _PDFViewSettings.fromWidget(widget),
+      settings: _PDFViewSettings.fromWidget(widget, resolvedColorMode: resolvedColorMode),
     );
   }
 

--- a/lib/src/pdf_view_controller.dart
+++ b/lib/src/pdf_view_controller.dart
@@ -7,12 +7,9 @@ part of '../flutter_pdfview.dart';
 /// happens automatically when the owning [PDFView] leaves the tree or loads a
 /// different document.
 class PDFViewController {
-  PDFViewController._(
-    int id,
-    PDFView widget, {
-    PdfColorMode resolvedColorMode = PdfColorMode.light,
-  }) : _channel = MethodChannel('plugins.endigo.io/pdfview_$id'),
-       _widget = widget {
+  PDFViewController._(int id, PDFView widget, {PdfColorMode resolvedColorMode = PdfColorMode.light})
+    : _channel = MethodChannel('plugins.endigo.io/pdfview_$id'),
+      _widget = widget {
     _settings = _PDFViewSettings.fromWidget(widget, resolvedColorMode: resolvedColorMode);
     _channel.setMethodCallHandler(_onMethodCall);
   }
@@ -207,10 +204,7 @@ class PDFViewController {
     return isSet;
   }
 
-  Future<void> _updateWidget(
-    PDFView widget, {
-    required PdfColorMode resolvedColorMode,
-  }) async {
+  Future<void> _updateWidget(PDFView widget, {required PdfColorMode resolvedColorMode}) async {
     _widget = widget;
     await _updateSettings(
       _PDFViewSettings.fromWidget(widget, resolvedColorMode: resolvedColorMode),

--- a/lib/src/pdf_view_controller.dart
+++ b/lib/src/pdf_view_controller.dart
@@ -7,17 +7,24 @@ part of '../flutter_pdfview.dart';
 /// happens automatically when the owning [PDFView] leaves the tree or loads a
 /// different document.
 class PDFViewController {
-  PDFViewController._(int id, PDFView widget)
-    : _channel = MethodChannel('plugins.endigo.io/pdfview_$id'),
-      _widget = widget {
-    _settings = _PDFViewSettings.fromWidget(widget);
+  PDFViewController._(
+    int id,
+    PDFView widget, {
+    PdfColorMode resolvedColorMode = PdfColorMode.light,
+  }) : _channel = MethodChannel('plugins.endigo.io/pdfview_$id'),
+       _widget = widget {
+    _settings = _PDFViewSettings.fromWidget(widget, resolvedColorMode: resolvedColorMode);
     _channel.setMethodCallHandler(_onMethodCall);
   }
 
   /// Test-only constructor so unit tests can exercise the method channel
   /// without a real platform view.
   @visibleForTesting
-  factory PDFViewController.test(int id, PDFView widget) => PDFViewController._(id, widget);
+  factory PDFViewController.test(
+    int id,
+    PDFView widget, {
+    PdfColorMode resolvedColorMode = PdfColorMode.light,
+  }) => PDFViewController._(id, widget, resolvedColorMode: resolvedColorMode);
 
   final MethodChannel _channel;
 
@@ -200,9 +207,14 @@ class PDFViewController {
     return isSet;
   }
 
-  Future<void> _updateWidget(PDFView widget) async {
+  Future<void> _updateWidget(
+    PDFView widget, {
+    required PdfColorMode resolvedColorMode,
+  }) async {
     _widget = widget;
-    await _updateSettings(_PDFViewSettings.fromWidget(widget));
+    await _updateSettings(
+      _PDFViewSettings.fromWidget(widget, resolvedColorMode: resolvedColorMode),
+    );
   }
 
   Future<void> _updateSettings(_PDFViewSettings setting) async {

--- a/lib/src/pdf_view_settings.dart
+++ b/lib/src/pdf_view_settings.dart
@@ -35,10 +35,7 @@ class _PDFViewSettings {
   ///
   /// [resolvedColorMode] must already be [PdfColorMode.light] or
   /// [PdfColorMode.dark] (never [PdfColorMode.system]).
-  static _PDFViewSettings fromWidget(
-    PDFView widget, {
-    required PdfColorMode resolvedColorMode,
-  }) {
+  static _PDFViewSettings fromWidget(PDFView widget, {required PdfColorMode resolvedColorMode}) {
     assert(
       resolvedColorMode != PdfColorMode.system,
       'system must be resolved before building settings',

--- a/lib/src/pdf_view_settings.dart
+++ b/lib/src/pdf_view_settings.dart
@@ -5,6 +5,9 @@ part of '../flutter_pdfview.dart';
 /// Used both to build the creation parameters for the native view and to compute
 /// the delta that has to be pushed over the method channel when the widget is
 /// rebuilt with different settings.
+///
+/// [colorMode] is always the **resolved** mode (`light` or `dark`); [PdfColorMode.system]
+/// is resolved in Dart from the ambient [Theme] before a settings snapshot is taken.
 class _PDFViewSettings {
   _PDFViewSettings({
     this.enableSwipe,
@@ -12,6 +15,7 @@ class _PDFViewSettings {
     this.showScrollIndicators,
     this.password,
     this.nightMode,
+    this.colorMode = PdfColorMode.light,
     this.autoSpacing,
     this.pageFling,
     this.pageSnap,
@@ -27,13 +31,25 @@ class _PDFViewSettings {
     this.minZoom,
   });
 
-  static _PDFViewSettings fromWidget(PDFView widget) {
+  /// Builds a settings snapshot from [widget].
+  ///
+  /// [resolvedColorMode] must already be [PdfColorMode.light] or
+  /// [PdfColorMode.dark] (never [PdfColorMode.system]).
+  static _PDFViewSettings fromWidget(
+    PDFView widget, {
+    required PdfColorMode resolvedColorMode,
+  }) {
+    assert(
+      resolvedColorMode != PdfColorMode.system,
+      'system must be resolved before building settings',
+    );
     return _PDFViewSettings(
       enableSwipe: widget.enableSwipe,
       swipeHorizontal: widget.swipeHorizontal,
       showScrollIndicators: widget.showScrollIndicators,
       password: widget.password,
       nightMode: widget.nightMode,
+      colorMode: resolvedColorMode,
       autoSpacing: widget.autoSpacing,
       pageFling: widget.pageFling,
       pageSnap: widget.pageSnap,
@@ -55,6 +71,10 @@ class _PDFViewSettings {
   final bool? showScrollIndicators;
   final String? password;
   final bool? nightMode;
+
+  /// Resolved color mode (`light` or `dark`) sent to the native view.
+  final PdfColorMode colorMode;
+
   final bool? autoSpacing;
   final bool? pageFling;
   final bool? pageSnap;
@@ -77,7 +97,9 @@ class _PDFViewSettings {
       'swipeHorizontal': swipeHorizontal,
       'showScrollIndicators': showScrollIndicators,
       'password': password,
+      // Kept for older native builds that only understand nightMode.
       'nightMode': nightMode,
+      'colorMode': colorMode.name,
       'autoSpacing': autoSpacing,
       'pageFling': pageFling,
       'pageSnap': pageSnap,
@@ -98,13 +120,16 @@ class _PDFViewSettings {
   ///
   /// Settings that the native side cannot update in place are deliberately left
   /// out of the diff.
+  ///
+  /// [backgroundColor] is omitted from the map when the new value is `null`
+  /// (clearing back to null at runtime leaves the last color on screen).
   Map<String, dynamic> updatesMap(_PDFViewSettings newSettings) {
     final Map<String, dynamic> updates = <String, dynamic>{};
     if (enableSwipe != newSettings.enableSwipe) {
       updates['enableSwipe'] = newSettings.enableSwipe;
     }
-    if (nightMode != newSettings.nightMode) {
-      updates['nightMode'] = newSettings.nightMode;
+    if (colorMode != newSettings.colorMode) {
+      updates['colorMode'] = newSettings.colorMode.name;
     }
     if (pageFling != newSettings.pageFling) {
       updates['pageFling'] = newSettings.pageFling;
@@ -120,6 +145,13 @@ class _PDFViewSettings {
     }
     if (minZoom != newSettings.minZoom) {
       updates['minZoom'] = newSettings.minZoom;
+    }
+    if (backgroundColor != newSettings.backgroundColor) {
+      final Color? bg = newSettings.backgroundColor;
+      if (bg != null) {
+        updates['backgroundColor'] = bg.toARGB32();
+      }
+      // Present-with-null is omitted; natives keep the previous color.
     }
     return updates;
   }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -50,3 +50,21 @@ enum FitPolicy {
   /// Scales each page so that it fits entirely inside the viewport.
   BOTH,
 }
+
+/// Color theme for PDF page content and the gutter behind it.
+///
+/// - [light]: normal rendering (no inversion).
+/// - [dark]: luminance-preserving inversion (white↔black, hue kept).
+/// - [system]: follows the app [Theme] brightness (or platform brightness when
+///   no [Theme] ancestor is present). Resolved in Dart before the value is
+///   sent to the native view.
+enum PdfColorMode {
+  /// Normal light rendering.
+  light,
+
+  /// Dark theme via luminance-preserving color inversion.
+  dark,
+
+  /// Follow the ambient app theme / platform brightness.
+  system,
+}

--- a/test/creation_params_test.dart
+++ b/test/creation_params_test.dart
@@ -13,6 +13,7 @@ const Set<String> _expectedKeys = <String>{
   'showScrollIndicators',
   'password',
   'nightMode',
+  'colorMode',
   'autoSpacing',
   'pageFling',
   'pageSnap',
@@ -128,6 +129,8 @@ void main() {
       expect(params['swipeHorizontal'], isFalse);
       expect(params['showScrollIndicators'], isFalse);
       expect(params['nightMode'], isFalse);
+      // Default colorMode is system; MaterialApp Theme is light → light.
+      expect(params['colorMode'], 'light');
       expect(params['autoSpacing'], isTrue);
       expect(params['pageFling'], isTrue);
       expect(params['pageSnap'], isTrue);
@@ -151,7 +154,7 @@ void main() {
           swipeHorizontal: true,
           showScrollIndicators: true,
           password: 's3cret',
-          nightMode: true,
+          colorMode: PdfColorMode.dark,
           autoSpacing: false,
           pageFling: false,
           pageSnap: false,
@@ -173,7 +176,7 @@ void main() {
       expect(params['enableSwipe'], isFalse);
       expect(params['swipeHorizontal'], isTrue);
       expect(params['showScrollIndicators'], isTrue);
-      expect(params['nightMode'], isTrue);
+      expect(params['colorMode'], 'dark');
       expect(params['autoSpacing'], isFalse);
       expect(params['pageFling'], isFalse);
       expect(params['pageSnap'], isFalse);
@@ -218,14 +221,73 @@ void main() {
       (WidgetTester tester) async {
         final Map<Object?, Object?> params = await pumpAndCapture(
           tester,
-          const PDFView(filePath: 'android.pdf', nightMode: true),
+          const PDFView(filePath: 'android.pdf', colorMode: PdfColorMode.dark),
         );
         expect(params.keys.cast<String>().toSet(), _expectedKeys);
         expect(params['filePath'], 'android.pdf');
-        expect(params['nightMode'], isTrue);
+        expect(params['colorMode'], 'dark');
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
+
+    testWidgets('serializes colorMode light and dark by name', (WidgetTester tester) async {
+      final Map<Object?, Object?> lightParams = await pumpAndCapture(
+        tester,
+        const PDFView(filePath: 'a.pdf', colorMode: PdfColorMode.light),
+      );
+      expect(lightParams['colorMode'], 'light');
+
+      // Remount with a new document so create fires again with dark params.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: PDFView(filePath: 'b.pdf', colorMode: PdfColorMode.dark)),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(created, hasLength(2));
+      expect(created.last['colorMode'], 'dark');
+    }, variant: _iOS);
+
+    testWidgets('deprecated nightMode: true resolves to dark when colorMode is system', (
+      WidgetTester tester,
+    ) async {
+      final Map<Object?, Object?> params = await pumpAndCapture(
+        tester,
+        // ignore: deprecated_member_use_from_same_package
+        const PDFView(filePath: 'a.pdf', nightMode: true),
+      );
+      expect(params['colorMode'], 'dark');
+      expect(params['nightMode'], isTrue);
+    }, variant: _iOS);
+
+    testWidgets('explicit colorMode beats deprecated nightMode', (WidgetTester tester) async {
+      final Map<Object?, Object?> params = await pumpAndCapture(
+        tester,
+        // ignore: deprecated_member_use_from_same_package
+        const PDFView(
+          filePath: 'a.pdf',
+          colorMode: PdfColorMode.light,
+          nightMode: true,
+        ),
+      );
+      expect(params['colorMode'], 'light');
+    }, variant: _iOS);
+
+    testWidgets('system colorMode resolves from ambient Theme brightness', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.light(),
+          darkTheme: ThemeData.dark(),
+          themeMode: ThemeMode.dark,
+          home: const Scaffold(body: PDFView(filePath: 'a.pdf')),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(created, hasLength(1));
+      expect(created.single['colorMode'], 'dark');
+    }, variant: _iOS);
   });
 
   group('Settings updates over the method channel', () {
@@ -244,8 +306,9 @@ void main() {
           home: Scaffold(
             body: PDFView(
               filePath: 'a.pdf',
-              nightMode: true,
+              colorMode: PdfColorMode.dark,
               maxZoom: 6.0,
+              backgroundColor: Color(0xFF112233),
               // Not part of the updatable diff.
               swipeHorizontal: true,
             ),
@@ -256,7 +319,45 @@ void main() {
 
       expect(created, hasLength(1), reason: 'settings-only change must not remount the view');
       expect(viewCalls.map((MethodCall c) => c.method), <String>['updateSettings']);
-      expect(viewCalls.single.arguments, <String, Object?>{'nightMode': true, 'maxZoom': 6.0});
+      expect(viewCalls.single.arguments, <String, Object?>{
+        'colorMode': 'dark',
+        'maxZoom': 6.0,
+        'backgroundColor': 0xFF112233,
+      });
+    }, variant: _iOS);
+
+    testWidgets('theme brightness change updates colorMode without remounting', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.light(),
+          darkTheme: ThemeData.dark(),
+          themeMode: ThemeMode.light,
+          home: const Scaffold(body: PDFView(filePath: 'a.pdf')),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(created, hasLength(1));
+      expect(created.single['colorMode'], 'light');
+      viewCalls.clear();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.light(),
+          darkTheme: ThemeData.dark(),
+          themeMode: ThemeMode.dark,
+          home: const Scaffold(body: PDFView(filePath: 'a.pdf')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(created, hasLength(1), reason: 'theme toggle must not remount the platform view');
+      final List<MethodCall> updates = viewCalls
+          .where((MethodCall c) => c.method == 'updateSettings')
+          .toList();
+      expect(updates, hasLength(1));
+      expect(updates.single.arguments, <String, Object?>{'colorMode': 'dark'});
     }, variant: _iOS);
 
     testWidgets('sends nothing when no updatable setting changed', (WidgetTester tester) async {

--- a/test/creation_params_test.dart
+++ b/test/creation_params_test.dart
@@ -240,7 +240,9 @@ void main() {
       // Remount with a new document so create fires again with dark params.
       await tester.pumpWidget(
         const MaterialApp(
-          home: Scaffold(body: PDFView(filePath: 'b.pdf', colorMode: PdfColorMode.dark)),
+          home: Scaffold(
+            body: PDFView(filePath: 'b.pdf', colorMode: PdfColorMode.dark),
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -264,11 +266,7 @@ void main() {
       final Map<Object?, Object?> params = await pumpAndCapture(
         tester,
         // ignore: deprecated_member_use_from_same_package
-        const PDFView(
-          filePath: 'a.pdf',
-          colorMode: PdfColorMode.light,
-          nightMode: true,
-        ),
+        const PDFView(filePath: 'a.pdf', colorMode: PdfColorMode.light, nightMode: true),
       );
       expect(params['colorMode'], 'light');
     }, variant: _iOS);

--- a/test/flutter_pdfview_test.dart
+++ b/test/flutter_pdfview_test.dart
@@ -32,7 +32,7 @@ void main() {
       filePath: 'test.pdf',
       enableSwipe: true,
       swipeHorizontal: false,
-      nightMode: false,
+      colorMode: PdfColorMode.light,
       autoSpacing: true,
       pageFling: true,
       pageSnap: true,
@@ -206,7 +206,7 @@ void main() {
         swipeHorizontal: true,
         showScrollIndicators: true,
         password: 's3cret',
-        nightMode: true,
+        colorMode: PdfColorMode.dark,
         autoSpacing: false,
         pageFling: false,
         pageSnap: false,
@@ -226,10 +226,10 @@ void main() {
       await tester.pump();
 
       // Smoke: widget still builds with the full settings surface used by the
-      // example app (nightMode, backgroundColor, zoom bounds, fit policy).
+      // example app (colorMode, backgroundColor, zoom bounds, fit policy).
       expect(find.byType(PDFView), findsOneWidget);
       expect(view.filePath, '/docs/demo.pdf');
-      expect(view.nightMode, isTrue);
+      expect(view.colorMode, PdfColorMode.dark);
       expect(view.backgroundColor, const Color(0xFF112233));
       expect(view.fitPolicy, FitPolicy.HEIGHT);
       expect(view.defaultPage, 3);
@@ -237,6 +237,15 @@ void main() {
       expect(view.minZoom, 0.5);
       expect(view.preventLinkNavigation, isTrue);
       expect(view.showScrollIndicators, isTrue);
+    });
+
+    test('PdfColorMode values are light, dark, system', () {
+      expect(PdfColorMode.values, <PdfColorMode>[
+        PdfColorMode.light,
+        PdfColorMode.dark,
+        PdfColorMode.system,
+      ]);
+      expect(PdfColorMode.dark.name, 'dark');
     });
 
     test('pdfData source is accepted without filePath', () {

--- a/test/issue_150_fit_params_test.dart
+++ b/test/issue_150_fit_params_test.dart
@@ -66,85 +66,97 @@ void main() {
   );
 
   group('Issue #150 creation params (iOS)', () {
-    testWidgets('reporter config keeps autoSpacing false and FitPolicy.BOTH', (WidgetTester tester) async {
-      final Map<Object?, Object?> params = await pumpAndCapture(tester, issue150Config);
+    testWidgets(
+      'reporter config keeps autoSpacing false and FitPolicy.BOTH',
+      (WidgetTester tester) async {
+        final Map<Object?, Object?> params = await pumpAndCapture(tester, issue150Config);
 
-      expect(params['autoSpacing'], isFalse, reason: 'spacing must not be forced true for fit');
-      expect(params['fitPolicy'], 'FitPolicy.BOTH');
-      expect(params['swipeHorizontal'], isFalse);
-      expect(params['enableSwipe'], isTrue);
-      expect(params['pageFling'], isTrue);
-      expect(params['pageSnap'], isTrue);
-      expect(params['defaultPage'], 0);
-      expect(params['preventLinkNavigation'], isFalse);
-    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+        expect(params['autoSpacing'], isFalse, reason: 'spacing must not be forced true for fit');
+        expect(params['fitPolicy'], 'FitPolicy.BOTH');
+        expect(params['swipeHorizontal'], isFalse);
+        expect(params['enableSwipe'], isTrue);
+        expect(params['pageFling'], isTrue);
+        expect(params['pageSnap'], isTrue);
+        expect(params['defaultPage'], 0);
+        expect(params['preventLinkNavigation'], isFalse);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
 
-    testWidgets('autoSpacing and fitPolicy serialize independently', (WidgetTester tester) async {
-      for (final bool autoSpacing in <bool>[true, false]) {
-        for (final FitPolicy policy in FitPolicy.values) {
-          // Tear down the previous platform view so the next create is recorded
-          // (settings-only rebuilds would not remount).
-          await tester.pumpWidget(const SizedBox.shrink());
-          await tester.pumpAndSettle();
-          created.clear();
+    testWidgets(
+      'autoSpacing and fitPolicy serialize independently',
+      (WidgetTester tester) async {
+        for (final bool autoSpacing in <bool>[true, false]) {
+          for (final FitPolicy policy in FitPolicy.values) {
+            // Tear down the previous platform view so the next create is recorded
+            // (settings-only rebuilds would not remount).
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pumpAndSettle();
+            created.clear();
 
-          final Map<Object?, Object?> params = await pumpAndCapture(
-            tester,
-            PDFView(
-              filePath: 'a.pdf',
-              autoSpacing: autoSpacing,
-              fitPolicy: policy,
-            ),
-          );
-          expect(
-            params['autoSpacing'],
-            autoSpacing,
-            reason: 'autoSpacing=$autoSpacing with $policy must pass through',
-          );
-          expect(
-            params['fitPolicy'],
-            policy.toString(),
-            reason: 'fitPolicy=$policy with autoSpacing=$autoSpacing must pass through',
-          );
+            final Map<Object?, Object?> params = await pumpAndCapture(
+              tester,
+              PDFView(filePath: 'a.pdf', autoSpacing: autoSpacing, fitPolicy: policy),
+            );
+            expect(
+              params['autoSpacing'],
+              autoSpacing,
+              reason: 'autoSpacing=$autoSpacing with $policy must pass through',
+            );
+            expect(
+              params['fitPolicy'],
+              policy.toString(),
+              reason: 'fitPolicy=$policy with autoSpacing=$autoSpacing must pass through',
+            );
+          }
         }
-      }
-    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
 
-    testWidgets('default still ships FitPolicy.WIDTH with autoSpacing true', (WidgetTester tester) async {
-      final Map<Object?, Object?> params = await pumpAndCapture(
-        tester,
-        const PDFView(filePath: 'a.pdf'),
-      );
-      // Defaults match Android so iOS no longer silently "fits both".
-      expect(params['fitPolicy'], 'FitPolicy.WIDTH');
-      expect(params['autoSpacing'], isTrue);
-    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+    testWidgets(
+      'default still ships FitPolicy.WIDTH with autoSpacing true',
+      (WidgetTester tester) async {
+        final Map<Object?, Object?> params = await pumpAndCapture(
+          tester,
+          const PDFView(filePath: 'a.pdf'),
+        );
+        // Defaults match Android so iOS no longer silently "fits both".
+        expect(params['fitPolicy'], 'FitPolicy.WIDTH');
+        expect(params['autoSpacing'], isTrue);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
   });
 
   group('Issue #150 creation params (Android)', () {
-    testWidgets('reporter config matches iOS serialization', (WidgetTester tester) async {
-      final Map<Object?, Object?> params = await pumpAndCapture(tester, issue150Config);
+    testWidgets(
+      'reporter config matches iOS serialization',
+      (WidgetTester tester) async {
+        final Map<Object?, Object?> params = await pumpAndCapture(tester, issue150Config);
 
-      expect(params['autoSpacing'], isFalse);
-      expect(params['fitPolicy'], 'FitPolicy.BOTH');
-      expect(params['enableSwipe'], isTrue);
-      expect(params['swipeHorizontal'], isFalse);
-    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+        expect(params['autoSpacing'], isFalse);
+        expect(params['fitPolicy'], 'FitPolicy.BOTH');
+        expect(params['enableSwipe'], isTrue);
+        expect(params['swipeHorizontal'], isFalse);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
 
-    testWidgets('autoSpacing false does not drop fitPolicy', (WidgetTester tester) async {
-      final Map<Object?, Object?> params = await pumpAndCapture(
-        tester,
-        const PDFView(
-          filePath: 'a.pdf',
-          autoSpacing: false,
-          fitPolicy: FitPolicy.WIDTH,
-        ),
-      );
-      expect(params.containsKey('autoSpacing'), isTrue);
-      expect(params.containsKey('fitPolicy'), isTrue);
-      expect(params['autoSpacing'], isFalse);
-      expect(params['fitPolicy'], 'FitPolicy.WIDTH');
-    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+    testWidgets(
+      'autoSpacing false does not drop fitPolicy',
+      (WidgetTester tester) async {
+        final Map<Object?, Object?> params = await pumpAndCapture(
+          tester,
+          const PDFView(filePath: 'a.pdf', autoSpacing: false, fitPolicy: FitPolicy.WIDTH),
+        );
+        expect(params.containsKey('autoSpacing'), isTrue);
+        expect(params.containsKey('fitPolicy'), isTrue);
+        expect(params['autoSpacing'], isFalse);
+        expect(params['fitPolicy'], 'FitPolicy.WIDTH');
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
   });
 
   group('Issue #150 FitPolicy enum contract', () {
@@ -158,10 +170,11 @@ void main() {
 
     test('all policies are covered', () {
       expect(FitPolicy.values, hasLength(3));
-      expect(
-        FitPolicy.values.map((FitPolicy p) => p.name).toSet(),
-        <String>{'WIDTH', 'HEIGHT', 'BOTH'},
-      );
+      expect(FitPolicy.values.map((FitPolicy p) => p.name).toSet(), <String>{
+        'WIDTH',
+        'HEIGHT',
+        'BOTH',
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
Dart-facing `colorMode` API that works with the Android and iOS native PRs in this stack.

- `enum PdfColorMode { light, dark, system }`
- `PDFView.colorMode` (default `system`); resolves from app `Theme` brightness
- Deprecates `nightMode` (still works when `colorMode` is left at default)
- `updatesMap` includes `colorMode` + `backgroundColor` for live theme changes without remount
- Example app: light/dark `ThemeMode` toggle, surface-based gutter color
- README + CHANGELOG updates
- Tests for serialization, nightMode compat, Theme resolution, no-remount updates

## Stack
1. Android colorMode
2. iOS colorMode + `onUpdateSettings`
3. **This PR** (Dart + example + docs)

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 99 tests passed
- [ ] Example: toggle theme on all sample screens; content + gutter change together