### PR TITLE
docs: iOS BackdropFilter/ColorFiltered limits (#213)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,54 @@ PDFView(
 )
 ```
 
+### BackdropFilter / ColorFiltered over PDFView (iOS)
+
+`PDFView` is a **platform view** (`UiKitView` on iOS, hybrid composition on
+Android). Flutter composites native views outside the normal Flutter layer
+tree, so some widgets that sample or recolor the scene **do not apply to the
+PDF pixels** — especially on iOS.
+
+| Widget | iOS platform view | Notes |
+|:-------|:-----------------:|:------|
+| `ColorFiltered` / `ShaderMask` | ❌ not supported | Official Flutter limitation |
+| `BackdropFilter` | ⚠️ partial | Supported with restrictions; needs a recent Flutter |
+
+This is **not a bug in flutter_pdfview**. Flutter documents it under
+[iOS platform view composition limitations](https://docs.flutter.dev/platform-integration/ios/platform-views#composition-limitations):
+`ShaderMask` and `ColorFiltered` are unsupported; `BackdropFilter` works only
+within the constraints of the
+[iOS Platform View Backdrop Filter design](https://flutter.dev/go/ios-platformview-backdrop-filter-blur).
+
+**Workarounds**
+
+1. **Color inversion / dark pages** — Prefer the plugin API instead of wrapping
+   the view in `ColorFiltered`:
+   - Android: `nightMode: true` (native invert).
+   - iOS: `nightMode` is not available today; use a theme-appropriate
+     `backgroundColor`, or invert offline content before load if you control the
+     PDF bytes.
+
+2. **Blur / glass under a sheet** — Place the `BackdropFilter` so it samples
+   Flutter-drawn content (not only the hole where the native PDF sits), use a
+   semi-transparent `barrierColor` / scrim, or capture a static preview with
+   `PDFViewController.getScreenshot` and blur that `Image` with Flutter widgets.
+
+3. **Static filtered preview** — For a one-shot recolor (e.g. thumbnail), take a
+   screenshot and wrap the resulting image:
+
+```dart
+final path = await controller.getScreenshot('preview.png');
+// Then:
+ColorFiltered(
+  colorFilter: const ColorFilter.mode(Colors.grey, BlendMode.saturation),
+  child: Image.file(File(path)),
+);
+```
+
+Wrapping `PDFView` itself in `ColorFiltered` will keep painting a solid tint
+*under* the native view on iOS while leaving the PDF contents unchanged
+([#213](https://github.com/endigo/flutter_pdfview/issues/213)).
+
 ## Controller Options
 
 | Name               |                                         Description                                          |                    Parameters                    |      Return      |


### PR DESCRIPTION
## Summary
- Closes/documents [#213](https://github.com/endigo/flutter_pdfview/issues/213): wrapping `PDFView` in `ColorFiltered` or relying on `BackdropFilter` over the native PDF on iOS is a **Flutter platform-view composition limitation**, not a plugin defect.
- README now explains the limitation with links to Flutter’s official docs and practical workarounds (`nightMode` on Android, scrim/layout for blur, screenshot + Flutter filter for static recolor).

## Evidence
Flutter iOS platform views docs ([composition limitations](https://docs.flutter.dev/platform-integration/ios/platform-views#composition-limitations)):
- `ShaderMask` and `ColorFiltered` are **not supported** over platform views.
- `BackdropFilter` is **partially** supported (see [design doc](https://flutter.dev/go/ios-platformview-backdrop-filter-blur)).

Reporter later noted BackdropFilter improved on Flutter master; ColorFiltered still does not work — matching Flutter’s current docs.

## Test plan
- [x] `flutter pub get`
- [x] `dart format .`
- [x] `flutter analyze` (no issues)
- [x] `flutter test` (all passed)
- Docs-only change; no Android native changes (no Android unit tests).

## Notes
- PR base: `migrate/kotlin-swift` (Kotlin/Swift branch).
- Package version **not** bumped (coordinator owns 1.5.0-beta.N).