### PR TITLE
fix: first-class onTap for PDFView (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Native language migration on both platforms. Includes everything in `1.4.5`.
 - Fix a platform-view remount race: late creation callbacks from a disposed or remounted view can no
   longer complete the new controller with a stale instance
 - Harden iOS `setZoomLimits` and align the podspec `swift_version`
-- No public Dart API changes
+- Add first-class `onTap` callback (Dart + Android + iOS) so single taps are reported from the
+  native PDF view; prefer this over `gestureRecognizers` + `TapGestureRecognizer`
+  ([#133](https://github.com/endigo/flutter_pdfview/issues/133))
 
 ## 1.4.5
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 | onPageChanged         |   ✅    | ✅  |      `null`       |
 | onLoadComplete        |   ✅    | ✅  |      `null`       |
 | onDraw                |   ✅    | ✅  |      `null`       |
+| onTap                 |   ✅    | ✅  |      `null`       |
 | onError               |   ✅    | ✅  |      `null`       |
 | onPageError           |   ✅    | ❌  |      `null`       |
 | onLinkHandle          |   ✅    | ✅  |      `null`       |
@@ -83,6 +84,25 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 Notes:
 - `showScrollIndicators` is ignored on iOS while horizontal page-flipping is active (`pageFling: true` together with `swipeHorizontal: true`).
 - `autoSpacing` only adds gaps between pages. It does not change initial zoom or `fitPolicy` (fixed in [#150](https://github.com/endigo/flutter_pdfview/issues/150)).
+
+### Detecting taps (`onTap`)
+
+For a reliable single-tap callback, use the first-class `onTap` parameter. It
+is delivered from the native PDF control on both platforms:
+
+```dart
+PDFView(
+  filePath: path,
+  onTap: () {
+    // e.g. toggle chrome / app bar
+  },
+)
+```
+
+Do **not** rely on `gestureRecognizers` with a `TapGestureRecognizer` for taps.
+Flutter’s platform-view gesture arena often never delivers `onTap` for embedded
+native views ([#133](https://github.com/endigo/flutter_pdfview/issues/133)).
+Keep `gestureRecognizers` for parent-scroll conflicts (below).
 
 ### Using PDFView inside a scrollable widget
 

--- a/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
+++ b/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
@@ -158,6 +158,14 @@ class FlutterPDFView(
                 .enableAntialiasing(getBoolean(params, "enableAntialiasing"))
                 .enableDoubletap(true)
                 .defaultPage(getInt(params, "defaultPage"))
+                // First-class tap callback (#133). Return false so links and
+                // double-tap zoom still receive the event.
+                .onTap { _ ->
+                    if (!disposed) {
+                        methodChannel.invokeMethod("onTap", null)
+                    }
+                    false
+                }
                 .onPageChange { page, total ->
                     if (disposed) return@onPageChange
                     val args: MutableMap<String, Any> = HashMap()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -286,6 +286,13 @@ class _PDFScreenState extends State<PDFScreen> with WidgetsBindingObserver {
               });
               debugPrint('onDraw - x offset: $pdfXOffset, y offset: $pdfYOffset scale: $pdfScale');
             },
+            // Prefer onTap over gestureRecognizers + TapGestureRecognizer (#133).
+            onTap: () {
+              debugPrint('PDFView onTap');
+              ScaffoldMessenger.of(
+                context,
+              ).showSnackBar(const SnackBar(content: Text('PDF tapped (onTap)')));
+            },
           ),
           _errorMessage.isEmpty
               ? !_isReady

--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
@@ -395,16 +395,32 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
             }
         }
 
-        let tapGestureRecognizer = UITapGestureRecognizer(
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(
             target: self,
             action: #selector(onDoubleTap(_:))
         )
-        tapGestureRecognizer.numberOfTapsRequired = 2
-        tapGestureRecognizer.numberOfTouchesRequired = 1
-        tapGestureRecognizer.delegate = self
-        tapGestureRecognizer.delaysTouchesBegan = false
-        tapGestureRecognizer.delaysTouchesEnded = false
-        pdfView.addGestureRecognizer(tapGestureRecognizer)
+        doubleTapGestureRecognizer.numberOfTapsRequired = 2
+        doubleTapGestureRecognizer.numberOfTouchesRequired = 1
+        doubleTapGestureRecognizer.delegate = self
+        doubleTapGestureRecognizer.delaysTouchesBegan = false
+        doubleTapGestureRecognizer.delaysTouchesEnded = false
+        pdfView.addGestureRecognizer(doubleTapGestureRecognizer)
+
+        // First-class single-tap callback for Dart onTap (#133). Platform-view
+        // gestureRecognizers are unreliable for TapGestureRecognizer; report
+        // taps from the native PDF view instead. Do not require the double-tap
+        // to fail so the callback stays responsive (double-tap zoom still works).
+        let singleTapGestureRecognizer = UITapGestureRecognizer(
+            target: self,
+            action: #selector(onSingleTap(_:))
+        )
+        singleTapGestureRecognizer.numberOfTapsRequired = 1
+        singleTapGestureRecognizer.numberOfTouchesRequired = 1
+        singleTapGestureRecognizer.delegate = self
+        singleTapGestureRecognizer.delaysTouchesBegan = false
+        singleTapGestureRecognizer.delaysTouchesEnded = false
+        singleTapGestureRecognizer.cancelsTouchesInView = false
+        pdfView.addGestureRecognizer(singleTapGestureRecognizer)
 
         let pageCount = document.pageCount
         if pageCount == 0 {
@@ -985,6 +1001,15 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
     }
 
     // MARK: - Gestures
+
+    @objc private func onSingleTap(_ recognizer: UITapGestureRecognizer) {
+        guard recognizer.state == .ended else { return }
+        // Skip while scrolling so page-fling / drag does not look like a tap.
+        if isScrolling {
+            return
+        }
+        controller?.invokeChannelMethod("onTap", arguments: nil)
+    }
 
     @objc private func onDoubleTap(_ recognizer: UITapGestureRecognizer) {
         guard recognizer.state == .ended else { return }

--- a/lib/src/pdf_view.dart
+++ b/lib/src/pdf_view.dart
@@ -27,6 +27,7 @@ class PDFView extends StatefulWidget {
     this.onLinkHandler,
     this.onLoadComplete,
     this.onDraw,
+    this.onTap,
     this.gestureRecognizers,
     this.enableSwipe = true,
     this.swipeHorizontal = false,
@@ -81,6 +82,17 @@ class PDFView extends StatefulWidget {
   /// Invoked while the document is drawn, with the current offsets and scale.
   final DrawCallback? onDraw;
 
+  /// Invoked when the user single-taps the PDF (native-side detection).
+  ///
+  /// This is the recommended way to react to taps. Using a [TapGestureRecognizer]
+  /// in [gestureRecognizers] is unreliable on platform views — the Flutter gesture
+  /// arena often loses the tap to the embedded native PDF control
+  /// ([#133](https://github.com/endigo/flutter_pdfview/issues/133)).
+  ///
+  /// Double-tap zoom and link handling still work; the native side reports the
+  /// single tap without consuming the event for those features.
+  final TapCallback? onTap;
+
   /// Which gestures should be consumed by the pdf view.
   ///
   /// It is possible for other gesture recognizers to be competing with the pdf view on pointer
@@ -90,6 +102,11 @@ class PDFView extends StatefulWidget {
   ///
   /// When this set is empty or null, the pdf view will only handle pointer events for gestures that
   /// were not claimed by any other gesture recognizer.
+  ///
+  /// **Tap detection:** prefer [onTap] instead of adding a [TapGestureRecognizer]
+  /// here. Platform-view gesture arenas frequently drop Flutter-side `onTap`
+  /// callbacks ([#133](https://github.com/endigo/flutter_pdfview/issues/133)). Use
+  /// this set for parent-scroll conflicts (e.g. [EagerGestureRecognizer]).
   final Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers;
 
   /// The path of the document to load from disk.

--- a/lib/src/pdf_view_controller.dart
+++ b/lib/src/pdf_view_controller.dart
@@ -72,6 +72,9 @@ class PDFViewController {
           call.arguments['pdfScale'],
         );
         return null;
+      case 'onTap':
+        widget.onTap?.call();
+        return null;
     }
     throw MissingPluginException('${call.method} was invoked but has no handler');
   }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -39,6 +39,15 @@ typedef LoadCompleteCallback = void Function(int? pages);
 /// reporting the current horizontal offset, vertical offset and zoom scale.
 typedef DrawCallback = void Function(double pdfXOffset, double pdfYOffset, double pdfScale);
 
+/// Signature for the callback that is invoked when the user single-taps the
+/// PDF view.
+///
+/// Prefer this over [PDFView.gestureRecognizers] with a [TapGestureRecognizer]
+/// when you only need a reliable tap notification — Flutter platform-view
+/// gesture arenas often fail to deliver `onTap` for embedded native views
+/// ([#133](https://github.com/endigo/flutter_pdfview/issues/133)).
+typedef TapCallback = void Function();
+
 /// Determines how the pages of a document are scaled to fit the viewport.
 enum FitPolicy {
   /// Scales each page so that its width fills the width of the viewport.

--- a/test/pdf_view_controller_test.dart
+++ b/test/pdf_view_controller_test.dart
@@ -391,6 +391,7 @@ void main() {
         onLinkHandler: (String? uri) => events.add('onLinkHandler($uri)'),
         onLoadComplete: (int? pages) => events.add('onLoadComplete($pages)'),
         onDraw: (double x, double y, double scale) => events.add('onDraw($x,$y,$scale)'),
+        onTap: () => events.add('onTap'),
       );
       controller = PDFViewController.test(_viewId, view);
     });
@@ -457,6 +458,16 @@ void main() {
         }),
       );
       expect(events, <String>['onDraw(1.5,2.5,3.5)']);
+    });
+
+    test('onTap is delivered with null arguments', () async {
+      await _emit(const MethodCall('onTap'));
+      expect(events, <String>['onTap']);
+    });
+
+    test('onTap tolerates an empty argument map', () async {
+      await _emit(const MethodCall('onTap', <String, Object?>{}));
+      expect(events, <String>['onTap']);
     });
 
     test('an unknown native method is reported as a missing plugin', () async {


### PR DESCRIPTION
## Summary
- Add a first-class `PDFView.onTap` callback delivered from native (Android `OnTapListener`, iOS single-tap recognizer) so apps get reliable taps without fighting the platform-view gesture arena.
- Document that `gestureRecognizers` + `TapGestureRecognizer` is unreliable; prefer `onTap`. Keep `gestureRecognizers` for parent-scroll conflicts (`EagerGestureRecognizer`).
- Example app shows a SnackBar on tap. Double-tap zoom and link handling remain intact (Android returns `false` from `onTap` so the event is not consumed).

Fixes #133

## Test plan
- [x] `flutter pub get && dart format . && flutter analyze && flutter test` (95 passed)
- [x] Android unit tests (`scripts/run_android_unit_tests.sh`) — all passed
- [ ] Manual: open example app → Open PDF → single-tap → SnackBar "PDF tapped (onTap)"
- [ ] Manual: double-tap still zooms; links still open / hit `onLinkHandler`

**Base:** `migrate/kotlin-swift` (not main). No package version bump.