### PR TITLE
docs: Android AcroForm / form field appearance limits (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Native language migration on both platforms. Includes everything in `1.4.5`.
 - Fix a platform-view remount race: late creation callbacks from a disposed or remounted view can no
   longer complete the new controller with a stale instance
 - Harden iOS `setZoomLimits` and align the podspec `swift_version`
+- Docs: AcroForm / fillable form field rendering limits on Android (Pdfium uses `/AP` appearance
+  streams and does not regenerate them like Adobe) — see [#303](https://github.com/endigo/flutter_pdfview/issues/303)
 - No public Dart API changes
 
 ## 1.4.5

--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ Notes:
 - `showScrollIndicators` is ignored on iOS while horizontal page-flipping is active (`pageFling: true` together with `swipeHorizontal: true`).
 - `autoSpacing` only adds gaps between pages. It does not change initial zoom or `fitPolicy` (fixed in [#150](https://github.com/endigo/flutter_pdfview/issues/150)).
 
+### AcroForm / fillable form fields
+
+This plugin is a **viewer**, not a form editor. Platform behavior:
+
+| Platform | Engine | Annotation / form field painting |
+|:---------|:-------|:---------------------------------|
+| Android  | Pdfium (via [AndroidPdfViewer](https://github.com/barteksc/AndroidPdfViewer)) | Widget appearance streams (`/AP`) are painted when `enableAnnotationRendering` is on (always enabled by this plugin). Pdfium does **not** regenerate appearances from `/V` + `/DA` the way Adobe Reader does. |
+| iOS      | PDFKit | Uses the system renderer; typically more tolerant of incomplete appearances. |
+
+**Implication:** if a PDF’s form field has a missing, empty, or **broken** `/AP` entry, Android can omit that field even when Adobe shows it. A common producer-side failure mode (seen with PDFBox + incremental saves / digital signing) is an object-number collision where the field’s `/AP` indirect reference is later reused for an XRef stream — the field value is still in the file, but the appearance object is no longer valid. See [#303](https://github.com/endigo/flutter_pdfview/issues/303).
+
+**Producer workarounds** (fix generators such as Apache PDFBox):
+
+1. After setting values, generate valid appearance streams (PDFBox: `setValue` / appearance generation; avoid leaving fields without a usable `/AP`).
+2. Prefer a full rewrite save when possible; after incremental updates (especially signing), re-check that each field’s `/AP` still resolves to a Form XObject, not an XRef or other object.
+3. Flatten fields when interactivity is not required (`PDAcroForm.flatten()`), so values become normal page content.
+4. Optionally set `/NeedAppearances true` on the AcroForm dictionary — some viewers honor it; **Pdfium generally still requires a real appearance stream** for reliable display.
+
+There is no plugin API that can repair malformed form appearances without embedding a full PDF rewrite stack (out of scope for this viewer).
+
 ### Using PDFView inside a scrollable widget
 
 When a `PDFView` is embedded in a scrollable parent (`SingleChildScrollView`,


### PR DESCRIPTION
## Summary

- Investigated [#303](https://github.com/endigo/flutter_pdfview/issues/303): first PDFBox `PDTextField` missing on Android while Adobe shows all fields.
- **Not a plugin bug / not fixable in-viewer.** Android already enables annotation rendering. Pdfium paints `/AP` appearance streams only and does not regenerate widget appearances from `/V` + `/DA` the way Adobe does.
- Root cause on the attached sample PDF: field `tb_187524_0` (`PDTextField 1`) has `/AP → 29 0 R`, but object 29 in the final document is an **XRef stream**, not a Form appearance dictionary (object-number collision from incremental updates / signing). Fields 2 and 3 still have valid `/AP` Form XObjects, which matches the reporter screenshots.
- Documented AcroForm limits and producer workarounds in README; CHANGELOG note under 1.5.0-beta.1 docs line.
- No package version bump (coordinator releases later). No native code changes.

## Test plan

- [x] `flutter pub get && dart format . && flutter analyze && flutter test` (all passed)
- [x] No Android code changes → skipped Android unit tests
- [ ] Review README “AcroForm / fillable form fields” section for accuracy