### PR TITLE
fix: load flash, first-layout size, iOS blank open (#40 #127 #190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+- Fix load flash / first-layout size / iOS blank open (for the next `1.5.0-beta.N`):
+  - [#40](https://github.com/endigo/flutter_pdfview/issues/40): keep the native view hidden until the
+    first successful render/fit so transitions do not flash an empty or mid-load surface
+  - [#127](https://github.com/endigo/flutter_pdfview/issues/127): harden first layout fit — defer
+    document open until a non-zero size, re-fit when the platform view settles after the first paint
+  - [#190](https://github.com/endigo/flutter_pdfview/issues/190): iOS defers `PDFDocument` open until
+    usable bounds, reports missing/unreadable/corrupt/empty documents via `onError`, and forces a
+    layout pass after attach so the PDF is not stuck blank until background/foreground
+
 ## 1.5.0-beta.2
 
 - Document iOS platform-view composition limits for `ColorFiltered` / `ShaderMask` / `BackdropFilter` over `PDFView`, with official Flutter evidence and workarounds ([#213](https://github.com/endigo/flutter_pdfview/issues/213), [#352](https://github.com/endigo/flutter_pdfview/pull/352))

--- a/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
+++ b/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
@@ -50,11 +50,23 @@ class FlutterPDFView(
     @Volatile
     private var documentLoadStarted = false
 
+    /** Width/height at the moment load started — used to detect a first-layout resize. */
+    private var loadWidth = 0
+    private var loadHeight = 0
+
+    /** True once onRender has revealed the view (or load failed and we un-hide). */
+    @Volatile
+    private var contentRevealed = false
+
+    /** Remains attached after load so a late size settle can re-fit (#127). */
+    private var sizeSettleListener: View.OnLayoutChangeListener? = null
+
     init {
         val view = PDFView(context, null)
         pdfView = view
-        // Prevent premature draw while the Hybrid Composition surface is still
-        // being attached (#263 Surface already locked, #280 EGL_NO_DISPLAY).
+        // Stay invisible until first successful render so transitions / first
+        // layout do not flash an empty or wrongly-fitted surface (#40, #127).
+        // Also avoids premature Hybrid Composition draws (#263, #280).
         view.visibility = View.INVISIBLE
         displayDensity = context.resources.displayMetrics.density
         val preventLinkNavigation = getBoolean(params, "preventLinkNavigation")
@@ -84,7 +96,7 @@ class FlutterPDFView(
 
         // Defer load until the view has a non-zero size so Pdfium does not render
         // into a zero-sized / unattached surface (#298 blank, #280 quick-open crash).
-        view.addOnLayoutChangeListener(object : View.OnLayoutChangeListener {
+        val initialLayoutListener = object : View.OnLayoutChangeListener {
             override fun onLayoutChange(
                 v: View, left: Int, top: Int, right: Int, bottom: Int,
                 oldLeft: Int, oldTop: Int, oldRight: Int, oldBottom: Int
@@ -98,9 +110,10 @@ class FlutterPDFView(
                 }
                 currentView.removeOnLayoutChangeListener(this)
                 loadDocument(params)
-                currentView.visibility = View.VISIBLE
+                // Keep INVISIBLE until onRender — do not flash mid-load (#40).
             }
-        })
+        }
+        view.addOnLayoutChangeListener(initialLayoutListener)
         // Fallback if layout already has size (e.g. recycled view / tests).
         view.post {
             val currentView = pdfView
@@ -108,10 +121,86 @@ class FlutterPDFView(
                 return@post
             }
             if (currentView.width > 0 && currentView.height > 0) {
+                currentView.removeOnLayoutChangeListener(initialLayoutListener)
                 loadDocument(params)
-                currentView.visibility = View.VISIBLE
             }
         }
+    }
+
+    private fun revealContent() {
+        if (contentRevealed || disposed) {
+            return
+        }
+        contentRevealed = true
+        pdfView?.visibility = View.VISIBLE
+    }
+
+    /**
+     * When the first non-zero layout is not the final size (common with hybrid
+     * composition and nested containers), re-apply default fit so the first
+     * painted frame matches the settled bounds (#127).
+     */
+    private fun attachSizeSettleListener(view: PDFView) {
+        sizeSettleListener?.let { view.removeOnLayoutChangeListener(it) }
+        val listener = View.OnLayoutChangeListener { v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
+            if (disposed || pdfView == null) {
+                return@OnLayoutChangeListener
+            }
+            val newW = right - left
+            val newH = bottom - top
+            val oldW = oldRight - oldLeft
+            val oldH = oldBottom - oldTop
+            if (newW <= 0 || newH <= 0) {
+                return@OnLayoutChangeListener
+            }
+            // Only care about meaningful size changes after load.
+            if (loadWidth <= 0 || loadHeight <= 0) {
+                return@OnLayoutChangeListener
+            }
+            val sizeChanged =
+                kotlin.math.abs(newW - loadWidth) > 1 || kotlin.math.abs(newH - loadHeight) > 1
+            val grewFromPrevious =
+                kotlin.math.abs(newW - oldW) > 1 || kotlin.math.abs(newH - oldH) > 1
+            if (!sizeChanged || !grewFromPrevious) {
+                return@OnLayoutChangeListener
+            }
+            // User still at default fit zoom (1f) — re-fit to new size.
+            val current = pdfView ?: return@OnLayoutChangeListener
+            if (current.pageCount <= 0) {
+                return@OnLayoutChangeListener
+            }
+            val atDefaultZoom = kotlin.math.abs(current.zoom - 1f) < 0.02f
+            if (!atDefaultZoom) {
+                // User has zoomed; stop watching for settle re-fit.
+                sizeSettleListener?.let { current.removeOnLayoutChangeListener(it) }
+                sizeSettleListener = null
+                return@OnLayoutChangeListener
+            }
+            loadWidth = newW
+            loadHeight = newH
+            try {
+                // jumpTo + zoomTo(1) forces AndroidPdfViewer to recompute fit
+                // against the new viewport after the late size settle.
+                current.zoomTo(1f)
+                current.loadPages()
+                current.invalidate()
+            } catch (e: Exception) {
+                Log.w(TAG, "size-settle re-fit", e)
+            }
+        }
+        sizeSettleListener = listener
+        view.addOnLayoutChangeListener(listener)
+        // Drop the settle listener after a short window — only first-load
+        // wrong size is in scope (#127), not every later resize/rotation
+        // (library onSizeChanged already handles those).
+        mainHandler.postDelayed({
+            val current = pdfView
+            val settle = sizeSettleListener
+            if (current != null && settle != null) {
+                current.removeOnLayoutChangeListener(settle)
+            }
+            sizeSettleListener = null
+        }, SIZE_SETTLE_WINDOW_MS)
     }
 
     private fun loadDocument(params: Map<String, Any?>) {
@@ -120,6 +209,8 @@ class FlutterPDFView(
             return
         }
         documentLoadStarted = true
+        loadWidth = view.width
+        loadHeight = view.height
         var config: Configurator? = null
         if (params["filePath"] != null) {
             val filePath = params["filePath"] as String
@@ -167,6 +258,9 @@ class FlutterPDFView(
                 }
                 .onError { t ->
                     if (disposed) return@onError
+                    // Un-hide so the host is not stuck with an invisible view
+                    // after a failed open.
+                    revealContent()
                     val args: MutableMap<String, Any> = HashMap()
                     args["error"] = t.toString()
                     methodChannel.invokeMethod("onError", args)
@@ -178,6 +272,29 @@ class FlutterPDFView(
                     methodChannel.invokeMethod("onPageError", args)
                 }.onRender { pages ->
                     if (disposed) return@onRender
+                    // First painted frame — safe to show (#40). Then watch for a
+                    // late size settle that needs a re-fit (#127).
+                    revealContent()
+                    attachSizeSettleListener(view)
+                    // One more pass on the next frame in case the surface size
+                    // changed between load and first draw.
+                    view.post {
+                        if (disposed || pdfView == null) return@post
+                        try {
+                            if (kotlin.math.abs(view.zoom - 1f) < 0.02f &&
+                                (view.width != loadWidth || view.height != loadHeight) &&
+                                view.width > 0 && view.height > 0
+                            ) {
+                                loadWidth = view.width
+                                loadHeight = view.height
+                                view.zoomTo(1f)
+                                view.loadPages()
+                            }
+                            view.invalidate()
+                        } catch (e: Exception) {
+                            Log.w(TAG, "post-render re-fit", e)
+                        }
+                    }
                     val args: MutableMap<String, Any> = HashMap()
                     args["pages"] = pages
                     methodChannel.invokeMethod("onRender", args)
@@ -205,6 +322,9 @@ class FlutterPDFView(
             }
             view.maxZoom = effectiveMax
             view.minZoom = effectiveMin
+        } else {
+            // No filePath / pdfData — reveal so the host is not stuck hidden.
+            revealContent()
         }
         configurator = config
     }
@@ -490,9 +610,17 @@ class FlutterPDFView(
         methodChannel.setMethodCallHandler(null)
         mainHandler.removeCallbacksAndMessages(null)
         val view = pdfView
+        val settle = sizeSettleListener
+        sizeSettleListener = null
         pdfView = null
         configurator = null
         if (view != null) {
+            if (settle != null) {
+                try {
+                    view.removeOnLayoutChangeListener(settle)
+                } catch (ignored: Exception) {
+                }
+            }
             try {
                 view.visibility = View.GONE
             } catch (ignored: Exception) {
@@ -534,6 +662,8 @@ class FlutterPDFView(
         private const val DEFAULT_MAX_ZOOM = 4.0f
         private const val DEFAULT_MIN_ZOOM = 1.0f
         private const val DRAW_THROTTLE_MS = 16L // ~1 frame at 60fps
+        /** How long to watch for a late first-layout size settle after onRender. */
+        private const val SIZE_SETTLE_WINDOW_MS = 750L
 
         @JvmStatic
         @VisibleForTesting

--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
@@ -228,12 +228,19 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
     private var hasSentInitialPage = false
     private var fitPolicy: FitPolicy = .width
     /// Last view size we laid out against — used to re-fit after the temporary
-    /// non-zero frame (#268) expands to the real Flutter bounds (#150).
+    /// non-zero frame (#268) expands to the real Flutter bounds (#150 / #127).
     private var lastLayoutSize: CGSize = .zero
     /// Fit scale applied for `lastLayoutSize` (before user zoom multiplier).
     private var lastFitScale: CGFloat = 0
     /// Whether we have successfully applied an initial fit at a real size.
     private var hasAppliedInitialFit = false
+    /// Creation args held until the view has a non-zero size (#190 / #127).
+    private var pendingLoadArguments: [String: Any]?
+    /// Ensures the document is opened at most once from creation args.
+    private var documentLoadStarted = false
+    /// Hide until first successful fit so callers do not see a flash of wrong
+    /// scale or an empty surface during transitions (#40).
+    private var isContentRevealed = false
 
     init(frame: CGRect, arguments args: Any?, controller: PDFViewController) {
         self.controller = controller
@@ -254,8 +261,49 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
         isScrolling = false
 
         pdfView.delegate = self
+        // Keep blank until first real-size fit to avoid flash / wrong initial
+        // scale when the platform view is still 0×0 or a placeholder (#40, #127).
+        pdfView.isHidden = true
+        isHidden = false
+        backgroundColor = .clear
 
-        loadDocument(arguments: args as? [String: Any])
+        pendingLoadArguments = args as? [String: Any]
+        // If Flutter already handed us a non-zero frame, open immediately;
+        // otherwise wait for layoutSubviews (#190 blank until foreground).
+        if hasUsableSize(bounds.size) {
+            beginDocumentLoadIfNeeded()
+        }
+    }
+
+    /// True when both dimensions are finite and large enough for PDFKit layout.
+    private func hasUsableSize(_ size: CGSize) -> Bool {
+        size.width.isFinite && size.height.isFinite && size.width > 1 && size.height > 1
+    }
+
+    private func beginDocumentLoadIfNeeded() {
+        guard !documentLoadStarted else { return }
+        documentLoadStarted = true
+        let args = pendingLoadArguments
+        pendingLoadArguments = nil
+        loadDocument(arguments: args)
+    }
+
+    private func reportError(_ message: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            // Reveal so a parent overlay / empty state is not stuck forever.
+            self.revealContentIfNeeded()
+            self.controller?.invokeChannelMethod(
+                "onError",
+                arguments: ["error": message]
+            )
+        }
+    }
+
+    private func revealContentIfNeeded() {
+        guard !isContentRevealed else { return }
+        isContentRevealed = true
+        pdfView.isHidden = false
     }
 
     @available(*, unavailable)
@@ -314,21 +362,51 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
             // Support plain paths and file:// URIs (#266 parity with Android).
             // URL(string:) returns nil for unescaped characters (spaces, etc.);
             // never fall back to fileURLWithPath on a full "file://..." string.
-            document = PDFDocument(url: Self.pdfURL(fromFilePath: filePath))
+            let url = Self.pdfURL(fromFilePath: filePath)
+            // Harden open path (#190): missing / unreadable files used to leave a
+            // blank PDFView with no onError until the app was backgrounded.
+            var isDirectory: ObjCBool = false
+            let exists = FileManager.default.fileExists(
+                atPath: url.path,
+                isDirectory: &isDirectory
+            )
+            if !exists || isDirectory.boolValue {
+                reportError(
+                    "cannot create document: File not found at \(url.path)."
+                )
+                return
+            }
+            if !FileManager.default.isReadableFile(atPath: url.path) {
+                reportError(
+                    "cannot create document: File is not readable at \(url.path)."
+                )
+                return
+            }
+            document = PDFDocument(url: url)
+            if document == nil {
+                reportError(
+                    "cannot create document: File not in PDF format or corrupted."
+                )
+                return
+            }
         } else if let pdfData = args?["pdfData"] as? FlutterStandardTypedData {
+            if pdfData.data.isEmpty {
+                reportError("cannot create document: pdfData is empty.")
+                return
+            }
             document = PDFDocument(data: pdfData.data)
+            if document == nil {
+                reportError(
+                    "cannot create document: File not in PDF format or corrupted."
+                )
+                return
+            }
         }
 
         guard let document else {
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                controller?.invokeChannelMethod(
-                    "onError",
-                    arguments: [
-                        "error": "cannot create document: File not in PDF format or corrupted.",
-                    ]
-                )
-            }
+            reportError(
+                "cannot create document: No filePath or pdfData provided."
+            )
             return
         }
 
@@ -385,13 +463,7 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
             if loadedDocument.isLocked {
                 // Android reports a PdfPasswordException through onError;
                 // without this the iOS view just stays blank.
-                DispatchQueue.main.async { [weak self] in
-                    guard let self else { return }
-                    controller?.invokeChannelMethod(
-                        "onError",
-                        arguments: ["error": "Password required or incorrect password."]
-                    )
-                }
+                reportError("Password required or incorrect password.")
             }
         }
 
@@ -410,13 +482,7 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
         if pageCount == 0 {
             // Defer like the nil-document path: the Dart handler is only
             // attached after the platform view is created.
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                controller?.invokeChannelMethod(
-                    "onError",
-                    arguments: ["error": "PDF has no pages."]
-                )
-            }
+            reportError("PDF has no pages.")
             return
         }
         // Objective-C compared an NSUInteger page count against an NSInteger
@@ -504,6 +570,16 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
             object: pdfView
         )
         addSubview(pdfView)
+
+        // Force a layout pass now that the document is attached so PDFKit
+        // installs its scroll hierarchy before we report onRender. Opening
+        // against a deferred non-zero size (#190) still needs an immediate
+        // fit so the first paint is correct (#127).
+        setNeedsLayout()
+        layoutIfNeeded()
+        if hasUsableSize(bounds.size) {
+            _ = applyLayoutUpdates()
+        }
     }
 
     deinit {
@@ -566,9 +642,14 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
         }
 
         // Guard against zero bounds — PDFKit NaN paths (#268).
-        if bounds.size.width <= 0 || bounds.size.height <= 0 {
+        if !hasUsableSize(bounds.size) {
             return
         }
+
+        // #190 / #127: open only once we have a real size so PDFKit does not
+        // lock to a 0×0 / placeholder layout that stays blank until the next
+        // app lifecycle event.
+        beginDocumentLoadIfNeeded()
 
         // Wrap layout updates in try-catch for safety
         var shouldUpdateCachedState = true
@@ -709,10 +790,18 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
             lastFitScale = fitScale
             lastLayoutSize = boundsSize
             hasAppliedInitialFit = true
+            // First correct fit at a real size — safe to show content (#40).
+            if hasUsableSize(boundsSize) {
+                revealContentIfNeeded()
+            }
         } else {
             // Still track size so a later change is detected; keep fit baseline.
             lastLayoutSize = boundsSize
             lastFitScale = fitScale
+            // If we already fit earlier, keep content visible after resizes.
+            if hasAppliedInitialFit {
+                revealContentIfNeeded()
+            }
         }
 
         if !hasSentInitialPage, defaultPageSet,
@@ -837,10 +926,20 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
     }
 
     func reload(_: FlutterMethodCall, result: FlutterResult) {
+        // If the initial open was deferred and never completed (still no size),
+        // try again now rather than reassigning a nil document.
+        if document == nil {
+            beginDocumentLoadIfNeeded()
+            result(NSNumber(value: document != nil))
+            return
+        }
+
         pdfView.document = document
         hasAppliedInitialFit = false
         lastFitScale = 0
         lastLayoutSize = .zero
+        isContentRevealed = false
+        pdfView.isHidden = true
         if let document, document.pageCount > 0, let firstPage = document.page(at: 0) {
             pdfView.go(to: firstPage)
 
@@ -856,6 +955,7 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
                 lastFitScale = fitScale
                 lastLayoutSize = bounds.size
                 hasAppliedInitialFit = true
+                revealContentIfNeeded()
             }
         }
 
@@ -949,12 +1049,25 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
     }
 
     private func handleRenderCompleted(_ pages: NSNumber) {
+        // If fit applied earlier we already revealed; if not (edge case where
+        // scale was not yet computable), still show so #190 does not leave a
+        // permanently hidden view after onRender.
+        if hasAppliedInitialFit || hasUsableSize(bounds.size) {
+            revealContentIfNeeded()
+        }
         controller?.invokeChannelMethod("onRender", arguments: ["pages": pages])
         if !didLoadComplete {
             didLoadComplete = true
             controller?.invokeChannelMethod("onLoadComplete", arguments: ["pages": pages])
         }
         startObserving()
+        // Post one more layout pass after PDFKit finishes installing pages so
+        // the first visible frame uses the real bounds (#127).
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.hasUsableSize(self.bounds.size) else { return }
+            self.setNeedsLayout()
+            self.layoutIfNeeded()
+        }
     }
 
     private func handleOnDraw() {


### PR DESCRIPTION
## Summary

Hardens first-load layout and document open paths on both platforms:

- **#40 (flash on load)**: keep the native PDF view hidden until the first successful render/fit so transitions and mid-load surfaces do not flash.
- **#127 (first-load wrong size)**: defer document open until a usable non-zero size; re-fit when the platform view settles after the first paint (Android size-settle window; iOS layout re-fit + post-render pass).
- **#190 (iOS PDF not loading)**: defer `PDFDocument` open until usable bounds; report missing/unreadable/empty/corrupt documents via `onError`; force a layout pass after attach so the PDF is not stuck blank until background/foreground.

No package version bump — coordinator will cut `1.5.0-beta.N`. Changelog notes live under `## Unreleased`.

## Changes

- `ios/.../FlutterPDFView.swift` — deferred load, reveal-after-fit, hardened open/error paths
- `android/.../FlutterPDFView.kt` — reveal on first `onRender`, post-render / size-settle re-fit
- `CHANGELOG.md` — Unreleased notes for #40 / #127 / #190

## Test plan

- [x] `flutter pub get`
- [x] `dart format .`
- [x] `flutter analyze` (no issues)
- [x] `flutter test` (all passed)
- [x] Android unit tests via `scripts/run_android_unit_tests.sh` (all passed)
- [ ] Manual: open PDF in example app after download on iOS (should show without background/foreground)
- [ ] Manual: embed PDF in a Transition / small container — no flash, correct first fit

## Base

`migrate/kotlin-swift` (not `main`). Do not merge until coordinator review.