### PR TITLE
fix: getScreenshot white screen under hybrid composition (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Native language migration on both platforms. Includes everything in `1.4.5`.
 - Fix a platform-view remount race: late creation callbacks from a disposed or remounted view can no
   longer complete the new controller with a stale instance
 - Harden iOS `setZoomLimits` and align the podspec `swift_version`
+- Fix [#175](https://github.com/endigo/flutter_pdfview/issues/175): `getScreenshot` no longer returns a
+  white image under hybrid composition. Android captures via `PixelCopy` (with a software-layer
+  `View.draw` fallback); iOS rasterizes the PDFKit layer and falls back to drawing the current
+  `PDFPage` (drawing-cache / hierarchy snapshots are avoided on both platforms)
 - No public Dart API changes
 
 ## 1.4.5

--- a/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
+++ b/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
@@ -1,13 +1,21 @@
 package io.endigo.plugins.pdfviewflutter
 
+import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Rect
+import android.graphics.drawable.ColorDrawable
 import android.net.Uri
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.view.PixelCopy
 import android.view.View
+import android.view.Window
 
 import androidx.annotation.VisibleForTesting
 
@@ -338,31 +346,114 @@ class FlutterPDFView(
             result.error("FAIL", "fileName is required", null)
             return
         }
-        try {
-            val outputFile = File(pdfFileName)
-            if (outputFile.parentFile == null) {
-                result.error("FAIL", "fileName must include a directory path", null)
+        val outputFile = File(pdfFileName)
+        if (outputFile.parentFile == null) {
+            result.error("FAIL", "fileName must include a directory path", null)
+            return
+        }
+        val view = pdfView
+        if (disposed || view == null) {
+            result.error("FAIL", "PDFView is not laid out yet", null)
+            return
+        }
+        val width = view.width
+        val height = view.height
+        if (width <= 0 || height <= 0) {
+            result.error("FAIL", "PDFView is not laid out yet", null)
+            return
+        }
+
+        // Prefer PixelCopy of the real window pixels when the hybrid-composition
+        // platform view is attached (#175). Fall back to a software-layer draw.
+        val window = findWindow(context)
+        if (window != null &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            view.isAttachedToWindow
+        ) {
+            val location = IntArray(2)
+            view.getLocationInWindow(location)
+            val srcRect = Rect(
+                location[0],
+                location[1],
+                location[0] + width,
+                location[1] + height
+            )
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            try {
+                PixelCopy.request(
+                    window,
+                    srcRect,
+                    bitmap,
+                    { copyResult ->
+                        if (disposed) {
+                            bitmap.recycle()
+                            result.error("FAIL", "PDFView disposed", null)
+                            return@request
+                        }
+                        if (copyResult == PixelCopy.SUCCESS) {
+                            writeScreenshot(outputFile, bitmap, result)
+                        } else {
+                            bitmap.recycle()
+                            val fallback = loadBitmapFromPDFView()
+                            if (fallback == null) {
+                                result.error(
+                                    "FAIL",
+                                    "Failed to generate image",
+                                    "PixelCopy result=$copyResult"
+                                )
+                            } else {
+                                writeScreenshot(outputFile, fallback, result)
+                            }
+                        }
+                    },
+                    mainHandler
+                )
                 return
+            } catch (e: IllegalArgumentException) {
+                // Window not ready / invalid rect — fall through to software draw.
+                bitmap.recycle()
+                Log.w(TAG, "PixelCopy unavailable, using software capture", e)
             }
-            val imageFileName = outputFile.absolutePath
+        }
+
+        try {
             val bmp = loadBitmapFromPDFView()
             if (bmp == null) {
                 result.error("FAIL", "PDFView is not laid out yet", null)
                 return
             }
-            try {
-                FileOutputStream(outputFile, false).use { fileOut ->
-                    bmp.compress(Bitmap.CompressFormat.PNG, 100, fileOut)
-                }
-            } finally {
-                bmp.recycle()
-            }
-            result.success(imageFileName)
+            writeScreenshot(outputFile, bmp, result)
         } catch (e: Exception) {
             result.error("FAIL", "Failed to generate image", e.message)
         }
     }
 
+    private fun writeScreenshot(outputFile: File, bmp: Bitmap, result: Result) {
+        try {
+            val parent = outputFile.parentFile
+            if (parent != null && !parent.exists()) {
+                parent.mkdirs()
+            }
+            FileOutputStream(outputFile, false).use { fileOut ->
+                bmp.compress(Bitmap.CompressFormat.PNG, 100, fileOut)
+            }
+            result.success(outputFile.absolutePath)
+        } catch (e: Exception) {
+            result.error("FAIL", "Failed to generate image", e.message)
+        } finally {
+            bmp.recycle()
+        }
+    }
+
+    /**
+     * Rasterizes the PDFView into an ARGB bitmap.
+     *
+     * A plain [View.draw] into a software [Canvas] returns a blank white image when
+     * the view (or its children) uses a hardware layer — which is the default under
+     * Flutter hybrid composition (`initExpensiveAndroidView`). Temporarily force a
+     * software layer so Pdfium page bitmaps are actually drawn into the capture (#175).
+     * Drawing-cache APIs are intentionally avoided; they are broken for the same reason.
+     */
     fun loadBitmapFromPDFView(): Bitmap? {
         val view = pdfView
         if (disposed || view == null) {
@@ -375,8 +466,36 @@ class FlutterPDFView(
         }
         val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
-        view.draw(canvas)
+        val background = view.background
+        if (background is ColorDrawable) {
+            canvas.drawColor(background.color)
+        } else if (background != null) {
+            background.setBounds(0, 0, width, height)
+            background.draw(canvas)
+        } else {
+            canvas.drawColor(Color.WHITE)
+        }
+        val previousLayerType = view.layerType
+        try {
+            // LAYER_TYPE_SOFTWARE rebuilds the display list into a CPU bitmap so
+            // subsequent draw() copies real page content instead of an empty HW layer.
+            view.setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+            view.draw(canvas)
+        } finally {
+            view.setLayerType(previousLayerType, null)
+        }
         return bitmap
+    }
+
+    private fun findWindow(context: Context): Window? {
+        var ctx: Context? = context
+        while (ctx is ContextWrapper) {
+            if (ctx is Activity) {
+                return ctx.window
+            }
+            ctx = ctx.baseContext
+        }
+        return null
     }
 
     fun reload(result: Result) {

--- a/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewScreenshotTest.java
+++ b/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewScreenshotTest.java
@@ -1,0 +1,89 @@
+package io.endigo.plugins.pdfviewflutter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.view.View;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Regression for #175: getScreenshot must produce a real bitmap under hybrid
+ * composition, not a drawing-cache / empty hardware-layer white frame.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 35)
+public class FlutterPDFViewScreenshotTest {
+
+    private Context context;
+    private BinaryMessenger messenger;
+    private int nextViewId;
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.getApplication();
+        messenger = mock(BinaryMessenger.class);
+    }
+
+    private FlutterPDFView newView() {
+        Map<String, Object> params = new HashMap<>();
+        return new FlutterPDFView(context, messenger, nextViewId++, params);
+    }
+
+    @Test
+    public void loadBitmap_returnsNullWhenNotLaidOut() {
+        FlutterPDFView flutterPdf = newView();
+        assertNull(flutterPdf.loadBitmapFromPDFView());
+    }
+
+    @Test
+    public void loadBitmap_returnsArgbBitmapOfViewSize() {
+        FlutterPDFView flutterPdf = newView();
+        View view = flutterPdf.getView();
+        assertNotNull(view);
+
+        view.measure(
+                View.MeasureSpec.makeMeasureSpec(240, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(320, View.MeasureSpec.EXACTLY));
+        view.layout(0, 0, 240, 320);
+
+        Bitmap bmp = flutterPdf.loadBitmapFromPDFView();
+        assertNotNull(bmp);
+        assertEquals(240, bmp.getWidth());
+        assertEquals(320, bmp.getHeight());
+        assertEquals(Bitmap.Config.ARGB_8888, bmp.getConfig());
+        bmp.recycle();
+    }
+
+    @Test
+    public void loadBitmap_restoresLayerTypeAfterCapture() {
+        FlutterPDFView flutterPdf = newView();
+        View view = flutterPdf.getView();
+        assertNotNull(view);
+
+        view.measure(
+                View.MeasureSpec.makeMeasureSpec(100, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(100, View.MeasureSpec.EXACTLY));
+        view.layout(0, 0, 100, 100);
+
+        int before = view.getLayerType();
+        Bitmap bmp = flutterPdf.loadBitmapFromPDFView();
+        assertNotNull(bmp);
+        assertEquals(before, view.getLayerType());
+        bmp.recycle();
+    }
+}

--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
@@ -166,13 +166,7 @@ final class PDFViewController: NSObject, FlutterPlatformView, PDFViewDelegate {
         case "reload":
             pdfView.reload(call, result: result)
         case "getScreenshot":
-            result(
-                FlutterError(
-                    code: "UNSUPPORTED",
-                    message: "getScreenshot is not implemented on iOS",
-                    details: nil
-                )
-            )
+            pdfView.getScreenshot(call, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -924,6 +918,197 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
             pdfView.maxScaleFactor = max(maxScale, minScale)
         }
         result(NSNumber(value: true))
+    }
+
+    /// Captures the currently visible PDF contents and writes a PNG to `fileName`.
+    ///
+    /// Flutter platform views / hybrid composition leave `drawHierarchy` and
+    /// snapshot helpers blank (white). We rasterize the real PDFKit layer, and
+    /// if that is still empty fall back to drawing the current [PDFPage]
+    /// into the viewport (#175).
+    func getScreenshot(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let fileName = (call.arguments as? [String: Any])?["fileName"] as? String,
+              !fileName.isEmpty
+        else {
+            result(
+                FlutterError(code: "FAIL", message: "fileName is required", details: nil)
+            )
+            return
+        }
+
+        let outputURL = URL(fileURLWithPath: fileName)
+        // Require a directory component so we don't silently write next to CWD.
+        guard outputURL.pathComponents.count > 1,
+              !outputURL.deletingLastPathComponent().path.isEmpty
+        else {
+            result(
+                FlutterError(
+                    code: "FAIL",
+                    message: "fileName must include a directory path",
+                    details: nil
+                )
+            )
+            return
+        }
+
+        let size = pdfView.bounds.size
+        guard size.width > 0, size.height > 0 else {
+            result(
+                FlutterError(
+                    code: "FAIL",
+                    message: "PDFView is not laid out yet",
+                    details: nil
+                )
+            )
+            return
+        }
+
+        let image: UIImage
+        var captureError: NSError?
+        var captured: UIImage?
+        catchingNSException {
+            captured = self.capturePDFImage(size: size)
+        } onException: { error in
+            captureError = error
+            NSLog("getScreenshot capture failed: %@", error.pdfExceptionDescription)
+        }
+
+        if let captureError {
+            result(
+                FlutterError(
+                    code: "FAIL",
+                    message: "Failed to generate image",
+                    details: captureError.pdfExceptionReason
+                )
+            )
+            return
+        }
+        guard let captured else {
+            result(
+                FlutterError(
+                    code: "FAIL",
+                    message: "Failed to generate image",
+                    details: nil
+                )
+            )
+            return
+        }
+        image = captured
+
+        guard let data = image.pngData() else {
+            result(
+                FlutterError(
+                    code: "FAIL",
+                    message: "Failed to generate image",
+                    details: "PNG encoding failed"
+                )
+            )
+            return
+        }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: outputURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: outputURL, options: .atomic)
+            result(outputURL.path)
+        } catch {
+            result(
+                FlutterError(
+                    code: "FAIL",
+                    message: "Failed to generate image",
+                    details: error.localizedDescription
+                )
+            )
+        }
+    }
+
+    /// Renders the visible PDF into a bitmap without relying on drawing-cache /
+    /// hierarchy snapshots (blank under Flutter platform views).
+    private func capturePDFImage(size: CGSize) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.opaque = true
+        format.scale = UIScreen.main.scale
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+
+        // 1) Preferred: rasterize the PDFKit layer (includes zoom/scroll).
+        let layerImage = renderer.image { ctx in
+            let cg = ctx.cgContext
+            (pdfView.backgroundColor ?? .white).setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+            pdfView.layer.render(in: cg)
+        }
+        if !isMostlyBlank(layerImage) {
+            return layerImage
+        }
+
+        // 2) Fallback: draw the current page into the viewport via PDFKit.
+        //    This always has real page content even when the platform-view layer
+        //    is not snapshot-friendly.
+        return renderer.image { ctx in
+            let cg = ctx.cgContext
+            (pdfView.backgroundColor ?? .white).setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+
+            guard let page = pdfView.currentPage else { return }
+            let pageRect = page.bounds(for: .mediaBox)
+            guard pageRect.width > 0, pageRect.height > 0 else { return }
+
+            // Fit the page into the viewport the same way PDFView would for a
+            // single-page snapshot (preserve aspect, center).
+            let scale = min(size.width / pageRect.width, size.height / pageRect.height)
+            let drawWidth = pageRect.width * scale
+            let drawHeight = pageRect.height * scale
+            let originX = (size.width - drawWidth) / 2
+            let originY = (size.height - drawHeight) / 2
+
+            cg.saveGState()
+            // PDFKit page coordinates are bottom-up; flip to UIKit space.
+            cg.translateBy(x: originX, y: originY + drawHeight)
+            cg.scaleBy(x: scale, y: -scale)
+            cg.translateBy(x: -pageRect.origin.x, y: -pageRect.origin.y)
+            page.draw(with: .mediaBox, to: cg)
+            cg.restoreGState()
+        }
+    }
+
+    /// True when the image is effectively solid white/empty (failed snapshot).
+    private func isMostlyBlank(_ image: UIImage) -> Bool {
+        guard let cgImage = image.cgImage else { return true }
+        // Downscale into a tiny buffer so we only inspect a handful of pixels.
+        let sampleW = 16
+        let sampleH = 16
+        let bytesPerPixel = 4
+        let bytesPerRow = bytesPerPixel * sampleW
+        var data = [UInt8](repeating: 0, count: bytesPerRow * sampleH)
+        guard let context = CGContext(
+            data: &data,
+            width: sampleW,
+            height: sampleH,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return false
+        }
+        context.interpolationQuality = .low
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleW, height: sampleH))
+
+        var nonWhite = 0
+        let total = sampleW * sampleH
+        for i in 0..<total {
+            let offset = i * bytesPerPixel
+            let r = data[offset]
+            let g = data[offset + 1]
+            let b = data[offset + 2]
+            if r < 250 || g < 250 || b < 250 {
+                nonWhite += 1
+            }
+        }
+        // If fewer than ~2% of samples have ink, treat as a blank capture.
+        return total == 0 || (Double(nonWhite) / Double(total)) < 0.02
     }
 
     // MARK: - Callbacks


### PR DESCRIPTION
## Summary

Fixes [#175](https://github.com/endigo/flutter_pdfview/issues/175): `getScreenshot` returned a blank white image.

Hybrid composition (`initExpensiveAndroidView`) and hardware layers break drawing-cache / plain `View.draw` captures. This PR captures **real PDF content** instead:

- **Android**: Prefer `PixelCopy` of the attached platform view; fall back to a temporary `LAYER_TYPE_SOFTWARE` + `View.draw` (no drawing cache).
- **iOS**: Implement `getScreenshot` by rasterizing the PDFKit layer; if that is blank, draw the current `PDFPage` into the viewport.

No package version bump (coordinator releases `1.5.0-beta.N`).

## Test plan

- [x] `flutter pub get && dart format . && flutter analyze && flutter test` — all passed
- [x] Android `./gradlew testDebugUnitTest` — all passed, including new `FlutterPDFViewScreenshotTest`
- [ ] Manual: load a PDF in the example app, call `controller.getScreenshot(path)`, open PNG and confirm page content (not white) on Android and iOS