### PR TITLE
fix: improve PDF render quality defaults (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- Improve Android/iOS render quality defaults for [#158](https://github.com/endigo/flutter_pdfview/issues/158):
+  density-aware page-part cache, apply Dart’s `thumbnailRatio` 0.8 when the param is omitted
+  (AndroidPdfViewer’s static default is 0.3), keep `useBestQuality` /
+  `enableAntialiasing` / `enableRenderDuringScale` true when params are missing, pin iOS
+  `contentScaleFactor` to the screen scale, and document quality knobs + hard Pdfium limits in the README
+
 ## 1.5.0-beta.2
 
 - Document iOS platform-view composition limits for `ColorFiltered` / `ShaderMask` / `BackdropFilter` over `PDFView`, with official Flutter evidence and workarounds ([#213](https://github.com/endigo/flutter_pdfview/issues/213), [#352](https://github.com/endigo/flutter_pdfview/pull/352))

--- a/README.md
+++ b/README.md
@@ -80,10 +80,57 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 | minZoom               |   ✅    | ✅  |        1.0        |
 | maxZoom               |   ✅    | ✅  |        4.0        |
 | showScrollIndicators* |   ✅    | ✅  |      `false`      |
+| enableAntialiasing   |   ✅    | ❌  |      `true`       |
+| useBestQuality        |   ✅    | ❌  |      `true`       |
+| enableRenderDuringScale | ✅    | ❌  |      `true`       |
+| thumbnailRatio*       |   ✅    | ❌  |        0.8        |
 
 Notes:
 - `showScrollIndicators` is ignored on iOS while horizontal page-flipping is active (`pageFling: true` together with `swipeHorizontal: true`).
 - `autoSpacing` only adds gaps between pages. It does not change initial zoom or `fitPolicy` (fixed in [#150](https://github.com/endigo/flutter_pdfview/issues/150)).
+- `thumbnailRatio` must be in `(0, 1]`. Higher values look sharper while tiles load but use more memory.
+
+### Render quality ([#158](https://github.com/endigo/flutter_pdfview/issues/158))
+
+**iOS (PDFKit)** draws PDF content as vectors at the screen scale. Text and line art
+should stay sharp when zooming. This plugin sets the platform view’s
+`contentScaleFactor` / layer `contentsScale` to the native display scale so
+Flutter embedding never leaves the layer at 1×.
+
+**Android (AndroidPdfViewer + Pdfium)** rasterizes each page into bitmap tiles:
+
+| Knob | What it does | Cost |
+|:-----|:-------------|:-----|
+| `useBestQuality: true` (default) | ARGB_8888 tiles instead of RGB_565 | ~2× bitmap memory vs 565 |
+| `enableAntialiasing: true` (default) | `FILTER_BITMAP` / AA when drawing tiles | Negligible |
+| `enableRenderDuringScale: true` (default) | Re-render tiles during pinch zoom | More CPU while pinching |
+| `thumbnailRatio` (default `0.8`) | Resolution of the full-page preview shown before high-res tiles arrive | Memory ∝ ratio² |
+
+On high-DPI devices the plugin also raises AndroidPdfViewer’s page-part cache
+slightly (still capped) so fewer tiles fall out of cache after zoom — the common
+“only part of the page is clear” report.
+
+**Hard limits (not a bug in this plugin):**
+
+- Tile spatial resolution matches the **view size in pixels**, not print DPI.
+  Small text on a phone-sized view will never look like a desktop PDF reader
+  without a different engine (supersampling / MuPDF / Android `PdfRenderer` at
+  higher scale). That would multiply memory and is intentionally not enabled by
+  default.
+- AndroidPdfViewer’s tile size / cache are process-wide statics; `thumbnailRatio`
+  from the first (or latest) view construction wins for the process.
+
+For the sharpest Android preview without a huge memory hit:
+
+```dart
+PDFView(
+  filePath: path,
+  useBestQuality: true,          // default
+  enableAntialiasing: true,    // default
+  enableRenderDuringScale: true, // default
+  thumbnailRatio: 1.0,           // full-page preview at 1:1 (more RAM)
+)
+```
 
 ### Using PDFView inside a scrollable widget
 

--- a/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
+++ b/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
@@ -64,17 +64,15 @@ class FlutterPDFView(
 
         linkHandler = PDFLinkHandler(context, view, methodChannel, preventLinkNavigation)
 
-        view.useBestQuality(getBoolean(params, "useBestQuality"))
-        view.enableRenderDuringScale(getBoolean(params, "enableRenderDuringScale"))
-        val thumbnailRatioObj = params["thumbnailRatio"]
-        if (thumbnailRatioObj is Number) {
-            val thumbnailRatio = thumbnailRatioObj.toFloat()
-            // A ratio outside (0, 1] makes AndroidPdfViewer create zero-sized or
-            // oversized thumbnail bitmaps, which throws at render time.
-            if (thumbnailRatio > 0f && thumbnailRatio <= 1f) {
-                Constants.THUMBNAIL_RATIO = thumbnailRatio
-            }
-        }
+        // Quality defaults match Dart PDFView so incomplete param maps still render
+        // with ARGB_8888, antialiasing, and live re-render while pinching (#158).
+        view.useBestQuality(
+            getBoolean(params, "useBestQuality", DEFAULT_USE_BEST_QUALITY)
+        )
+        view.enableRenderDuringScale(
+            getBoolean(params, "enableRenderDuringScale", DEFAULT_ENABLE_RENDER_DURING_SCALE)
+        )
+        applyDisplayQualityDefaults(displayDensity, params)
 
         val backgroundColor = params["backgroundColor"]
         if (backgroundColor != null) {
@@ -155,7 +153,9 @@ class FlutterPDFView(
                     if (getBoolean(params, "showScrollIndicators")) DefaultScrollHandle(context) else null
                 )
                 .linkHandler(linkHandler)
-                .enableAntialiasing(getBoolean(params, "enableAntialiasing"))
+                .enableAntialiasing(
+                    getBoolean(params, "enableAntialiasing", DEFAULT_ENABLE_ANTIALIASING)
+                )
                 .enableDoubletap(true)
                 .defaultPage(getInt(params, "defaultPage"))
                 .onPageChange { page, total ->
@@ -535,12 +535,102 @@ class FlutterPDFView(
         private const val DEFAULT_MIN_ZOOM = 1.0f
         private const val DRAW_THROTTLE_MS = 16L // ~1 frame at 60fps
 
+        /** Matches Dart [PDFView.useBestQuality] default (ARGB_8888 vs RGB_565). */
+        const val DEFAULT_USE_BEST_QUALITY = true
+
+        /** Matches Dart [PDFView.enableAntialiasing] default. */
+        const val DEFAULT_ENABLE_ANTIALIASING = true
+
+        /** Matches Dart [PDFView.enableRenderDuringScale] default. */
+        const val DEFAULT_ENABLE_RENDER_DURING_SCALE = true
+
+        /**
+         * Matches Dart [PDFView.thumbnailRatio] default. AndroidPdfViewer's own
+         * static default is 0.3, which looks soft while high-res tiles load (#158).
+         */
+        const val DEFAULT_THUMBNAIL_RATIO = 0.8f
+
+        /** AndroidPdfViewer library baseline for [Constants.Cache.CACHE_SIZE]. */
+        const val BASE_PAGE_PART_CACHE_SIZE = 120
+
+        /** AndroidPdfViewer library baseline for [Constants.Cache.THUMBNAILS_CACHE_SIZE]. */
+        const val BASE_THUMBNAIL_CACHE_SIZE = 8
+
+        /**
+         * Applies process-wide AndroidPdfViewer [Constants] for render quality.
+         *
+         * - [Constants.THUMBNAIL_RATIO]: from params when in (0, 1], else Dart's 0.8
+         *   default (library default 0.3 is notably soft on modern phones).
+         * - Cache sizes: raised modestly on high-DPI displays. A dense viewport
+         *   covers more 256px page tiles; keeping more of them reduces the common
+         *   "only some of the page is sharp after zoom" effect without supersampling
+         *   (which would 2–4× bitmap memory). Growth is capped (~+80 tiles ≈ +20MB
+         *   worst case for ARGB_8888 256² tiles).
+         *
+         * These statics are process-wide (AndroidPdfViewer design). We only ever
+         * raise cache sizes so concurrent views do not shrink a larger setting.
+         */
+        @JvmStatic
+        @VisibleForTesting
+        fun applyDisplayQualityDefaults(density: Float, params: Map<String, Any?>) {
+            val thumbnailRatioObj = params["thumbnailRatio"]
+            if (thumbnailRatioObj is Number) {
+                val thumbnailRatio = thumbnailRatioObj.toFloat()
+                // A ratio outside (0, 1] makes AndroidPdfViewer create zero-sized or
+                // oversized thumbnail bitmaps, which throws at render time.
+                if (thumbnailRatio > 0f && thumbnailRatio <= 1f) {
+                    Constants.THUMBNAIL_RATIO = thumbnailRatio
+                }
+            } else {
+                Constants.THUMBNAIL_RATIO = DEFAULT_THUMBNAIL_RATIO
+            }
+
+            val sizes = cacheSizesForDensity(density)
+            val cacheSize = sizes[0]
+            val thumbnailCacheSize = sizes[1]
+            if (Constants.Cache.CACHE_SIZE < cacheSize) {
+                Constants.Cache.CACHE_SIZE = cacheSize
+            }
+            if (Constants.Cache.THUMBNAILS_CACHE_SIZE < thumbnailCacheSize) {
+                Constants.Cache.THUMBNAILS_CACHE_SIZE = thumbnailCacheSize
+            }
+        }
+
+        /**
+         * Page-part and thumbnail cache sizes for a display density.
+         *
+         * Returns `{pagePartCache, thumbnailCache}` — library baselines at 1× density;
+         * steps up at 2× / 2.5× / 3.5× (roughly xhdpi / xxhdpi / high-end xxxhdpi+).
+         */
+        @JvmStatic
+        @VisibleForTesting
+        fun cacheSizesForDensity(density: Float): IntArray {
+            return when {
+                density >= 3.5f -> intArrayOf(200, 16)
+                density >= 2.5f -> intArrayOf(180, 12)
+                density >= 2.0f -> intArrayOf(150, 10)
+                else -> intArrayOf(BASE_PAGE_PART_CACHE_SIZE, BASE_THUMBNAIL_CACHE_SIZE)
+            }
+        }
+
         @JvmStatic
         @VisibleForTesting
         fun getBoolean(params: Map<String, Any?>, key: String): Boolean {
+            return getBoolean(params, key, false)
+        }
+
+        /**
+         * Reads a boolean creation param, returning [defaultValue] when the key is
+         * missing or the value is null.
+         */
+        @JvmStatic
+        @VisibleForTesting
+        fun getBoolean(params: Map<String, Any?>, key: String, defaultValue: Boolean): Boolean {
+            if (!params.containsKey(key)) {
+                return defaultValue
+            }
             val keyObj = params[key] as Boolean?
-            val bKey: Boolean = keyObj ?: false
-            return params.containsKey(key) && bKey
+            return keyObj ?: defaultValue
         }
 
         @JvmStatic

--- a/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewQualityDefaultsTest.java
+++ b/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewQualityDefaultsTest.java
@@ -1,0 +1,166 @@
+package io.endigo.plugins.pdfviewflutter;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.github.barteksc.pdfviewer.util.Constants;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Density-aware quality defaults and boolean param fallbacks for #158.
+ *
+ * AndroidPdfViewer exposes process-wide statics ({@link Constants#THUMBNAIL_RATIO},
+ * {@link Constants.Cache}). These tests restore them after each case.
+ */
+public class FlutterPDFViewQualityDefaultsTest {
+
+    private float originalThumbnailRatio;
+    private int originalCacheSize;
+    private int originalThumbnailCacheSize;
+
+    @Before
+    public void setUp() {
+        originalThumbnailRatio = Constants.THUMBNAIL_RATIO;
+        originalCacheSize = Constants.Cache.CACHE_SIZE;
+        originalThumbnailCacheSize = Constants.Cache.THUMBNAILS_CACHE_SIZE;
+    }
+
+    @After
+    public void tearDown() {
+        Constants.THUMBNAIL_RATIO = originalThumbnailRatio;
+        Constants.Cache.CACHE_SIZE = originalCacheSize;
+        Constants.Cache.THUMBNAILS_CACHE_SIZE = originalThumbnailCacheSize;
+    }
+
+    // ------------------------------------------------- cacheSizesForDensity
+
+    @Test
+    public void cacheSizes_ldpi_usesLibraryBaselines() {
+        assertArrayEquals(
+                new int[]{
+                        FlutterPDFView.BASE_PAGE_PART_CACHE_SIZE,
+                        FlutterPDFView.BASE_THUMBNAIL_CACHE_SIZE
+                },
+                FlutterPDFView.cacheSizesForDensity(1.0f));
+    }
+
+    @Test
+    public void cacheSizes_justBelow2x_stillBaseline() {
+        assertArrayEquals(
+                new int[]{
+                        FlutterPDFView.BASE_PAGE_PART_CACHE_SIZE,
+                        FlutterPDFView.BASE_THUMBNAIL_CACHE_SIZE
+                },
+                FlutterPDFView.cacheSizesForDensity(1.99f));
+    }
+
+    @Test
+    public void cacheSizes_xhdpi() {
+        assertArrayEquals(new int[]{150, 10}, FlutterPDFView.cacheSizesForDensity(2.0f));
+    }
+
+    @Test
+    public void cacheSizes_xxhdpi() {
+        assertArrayEquals(new int[]{180, 12}, FlutterPDFView.cacheSizesForDensity(2.5f));
+        assertArrayEquals(new int[]{180, 12}, FlutterPDFView.cacheSizesForDensity(3.0f));
+    }
+
+    @Test
+    public void cacheSizes_highXxxhdpi() {
+        assertArrayEquals(new int[]{200, 16}, FlutterPDFView.cacheSizesForDensity(3.5f));
+        assertArrayEquals(new int[]{200, 16}, FlutterPDFView.cacheSizesForDensity(4.0f));
+    }
+
+    // ----------------------------------------- applyDisplayQualityDefaults
+
+    @Test
+    public void applyDefaults_missingThumbnail_usesPluginDefault() {
+        Constants.THUMBNAIL_RATIO = 0.3f;
+        FlutterPDFView.applyDisplayQualityDefaults(1.0f, Collections.emptyMap());
+        assertEquals(FlutterPDFView.DEFAULT_THUMBNAIL_RATIO, Constants.THUMBNAIL_RATIO, 0f);
+    }
+
+    @Test
+    public void applyDefaults_explicitThumbnail_isApplied() {
+        FlutterPDFView.applyDisplayQualityDefaults(
+                1.0f, Collections.singletonMap("thumbnailRatio", 0.55d));
+        assertEquals(0.55f, Constants.THUMBNAIL_RATIO, 0f);
+    }
+
+    @Test
+    public void applyDefaults_invalidThumbnail_doesNotOverwrite() {
+        Constants.THUMBNAIL_RATIO = 0.42f;
+        Map<String, Object> params = new HashMap<>();
+        params.put("thumbnailRatio", 1.5d);
+        FlutterPDFView.applyDisplayQualityDefaults(1.0f, params);
+        assertEquals(0.42f, Constants.THUMBNAIL_RATIO, 0f);
+    }
+
+    @Test
+    public void applyDefaults_raisesCacheOnHighDpi() {
+        Constants.Cache.CACHE_SIZE = FlutterPDFView.BASE_PAGE_PART_CACHE_SIZE;
+        Constants.Cache.THUMBNAILS_CACHE_SIZE = FlutterPDFView.BASE_THUMBNAIL_CACHE_SIZE;
+        FlutterPDFView.applyDisplayQualityDefaults(3.0f, Collections.emptyMap());
+        assertEquals(180, Constants.Cache.CACHE_SIZE);
+        assertEquals(12, Constants.Cache.THUMBNAILS_CACHE_SIZE);
+    }
+
+    @Test
+    public void applyDefaults_neverLowersExistingLargerCache() {
+        Constants.Cache.CACHE_SIZE = 500;
+        Constants.Cache.THUMBNAILS_CACHE_SIZE = 40;
+        FlutterPDFView.applyDisplayQualityDefaults(3.0f, Collections.emptyMap());
+        assertEquals(500, Constants.Cache.CACHE_SIZE);
+        assertEquals(40, Constants.Cache.THUMBNAILS_CACHE_SIZE);
+    }
+
+    @Test
+    public void applyDefaults_ldpi_leavesBaselines() {
+        Constants.Cache.CACHE_SIZE = FlutterPDFView.BASE_PAGE_PART_CACHE_SIZE;
+        Constants.Cache.THUMBNAILS_CACHE_SIZE = FlutterPDFView.BASE_THUMBNAIL_CACHE_SIZE;
+        FlutterPDFView.applyDisplayQualityDefaults(1.0f, Collections.emptyMap());
+        assertEquals(FlutterPDFView.BASE_PAGE_PART_CACHE_SIZE, Constants.Cache.CACHE_SIZE);
+        assertEquals(FlutterPDFView.BASE_THUMBNAIL_CACHE_SIZE, Constants.Cache.THUMBNAILS_CACHE_SIZE);
+    }
+
+    // --------------------------------------------- getBoolean with default
+
+    @Test
+    public void getBoolean_withDefault_missingKey_returnsDefault() {
+        assertTrue(FlutterPDFView.getBoolean(Collections.emptyMap(), "useBestQuality", true));
+        assertFalse(FlutterPDFView.getBoolean(Collections.emptyMap(), "useBestQuality", false));
+    }
+
+    @Test
+    public void getBoolean_withDefault_presentFalse_wins() {
+        assertFalse(
+                FlutterPDFView.getBoolean(
+                        Collections.singletonMap("useBestQuality", false),
+                        "useBestQuality",
+                        true));
+    }
+
+    @Test
+    public void getBoolean_withDefault_nullValue_returnsDefault() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("useBestQuality", null);
+        assertTrue(FlutterPDFView.getBoolean(params, "useBestQuality", true));
+    }
+
+    @Test
+    public void qualityFlagDefaults_matchDartPdfView() {
+        assertTrue(FlutterPDFView.DEFAULT_USE_BEST_QUALITY);
+        assertTrue(FlutterPDFView.DEFAULT_ENABLE_ANTIALIASING);
+        assertTrue(FlutterPDFView.DEFAULT_ENABLE_RENDER_DURING_SCALE);
+        assertEquals(0.8f, FlutterPDFView.DEFAULT_THUMBNAIL_RATIO, 0f);
+    }
+}

--- a/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewThumbnailRatioTest.java
+++ b/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewThumbnailRatioTest.java
@@ -77,13 +77,16 @@ public class FlutterPDFViewThumbnailRatioTest {
     }
 
     @Test
-    public void nonNumericValue_isRejected() {
-        assertEquals(SENTINEL, ratioAfterCreating("0.5"), 0f);
+    public void nonNumericValue_fallsBackToPluginDefault() {
+        // Same path as a missing param: only Numbers in (0, 1] write the static.
+        assertEquals(FlutterPDFView.DEFAULT_THUMBNAIL_RATIO, ratioAfterCreating("0.5"), 0f);
     }
 
     @Test
-    public void missingValue_leavesGlobalUntouched() {
-        assertEquals(SENTINEL, ratioAfterCreating(null), 0f);
+    public void missingValue_appliesPluginDefault() {
+        // #158: AndroidPdfViewer defaults to 0.3; the plugin matches Dart's 0.8
+        // when the creation param is omitted so first paint is not soft.
+        assertEquals(FlutterPDFView.DEFAULT_THUMBNAIL_RATIO, ratioAfterCreating(null), 0f);
     }
 
     @Test

--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
@@ -254,6 +254,9 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
         isScrolling = false
 
         pdfView.delegate = self
+        // PDFKit is vector, but ensure the host layer is not stuck at 1× when the
+        // Flutter platform view attaches before a window is available (#158).
+        applyDisplayScale()
 
         loadDocument(arguments: args as? [String: Any])
     }
@@ -557,8 +560,32 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
         contentOffsetObservation = nil
     }
 
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        applyDisplayScale()
+    }
+
+    /// Matches the PDFView layer to the screen's native scale (Retina / ProMotion).
+    private func applyDisplayScale() {
+        let scale = window?.screen.scale ?? UIScreen.main.scale
+        guard scale > 0 else { return }
+        if abs(pdfView.contentScaleFactor - scale) > 0.01 {
+            pdfView.contentScaleFactor = scale
+        }
+        if abs(pdfView.layer.contentsScale - scale) > 0.01 {
+            pdfView.layer.contentsScale = scale
+        }
+        if abs(contentScaleFactor - scale) > 0.01 {
+            contentScaleFactor = scale
+        }
+        if abs(layer.contentsScale - scale) > 0.01 {
+            layer.contentsScale = scale
+        }
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
+        applyDisplayScale()
 
         // Skip layout updates during scrolling to prevent conflicts
         if isScrolling {

--- a/lib/src/pdf_view.dart
+++ b/lib/src/pdf_view.dart
@@ -134,18 +134,36 @@ class PDFView extends StatefulWidget {
   /// If set to true, snapping is enabled. No effect on iOS.
   final bool pageSnap;
 
-  /// Controls whether the PDF renderer uses anti-aliasing (Android only).
+  /// Controls whether the PDF renderer uses anti-aliasing when compositing
+  /// page bitmaps (Android only; default `true`).
+  ///
+  /// No effect on iOS (PDFKit is vector). See the README "Render quality"
+  /// section and [#158](https://github.com/endigo/flutter_pdfview/issues/158).
   final bool enableAntialiasing;
 
-  /// Improves render quality at the cost of performance (Android only).
+  /// Uses full-color ARGB_8888 page bitmaps instead of RGB_565 (Android only;
+  /// default `true`).
+  ///
+  /// This improves color fidelity and text edges slightly. It does **not**
+  /// increase spatial resolution — AndroidPdfViewer still rasterizes at view
+  /// pixel size. Prefer raising [thumbnailRatio] for sharper low-res previews.
+  /// No effect on iOS.
   final bool useBestQuality;
 
-  /// Renders during scale gestures for smoother zooming (Android only).
+  /// Re-rasterizes page tiles while the user pinches to zoom (Android only;
+  /// default `true`).
+  ///
+  /// Without this, zoomed regions stay blurry until the gesture ends. Costs
+  /// more CPU/GPU during the pinch. No effect on iOS.
   final bool enableRenderDuringScale;
 
-  /// Thumbnail ratio used by AndroidPdfViewer (Android only).
+  /// Full-page preview scale used by AndroidPdfViewer while high-res tiles
+  /// load (Android only).
   ///
-  /// Must be within `(0, 1]` when it is not null.
+  /// Library default inside AndroidPdfViewer is `0.3`; this plugin defaults to
+  /// `0.8` for a sharper first paint. Must be within `(0, 1]` when non-null.
+  /// `1.0` is sharpest but uses more memory (one full-page bitmap per cached
+  /// page). No effect on iOS.
   final double? thumbnailRatio;
 
   /// The page to display when the PDF document is loaded.


### PR DESCRIPTION
## Summary

Addresses [#158](https://github.com/endigo/flutter_pdfview/issues/158) (low-quality PDF text/images) with **safe, density-aware defaults** and clear documentation of hard engine limits. No package version bump (for the 1.5.0 beta line coordinator).

### Investigation

| Platform | Engine | Quality model |
|:---------|:-------|:--------------|
| Android | AndroidPdfViewer + Pdfium | Rasterizes page **tiles** at view pixel size. `useBestQuality` only switches ARGB_8888 vs RGB_565 (not spatial resolution). Soft first paint comes from `THUMBNAIL_RATIO` (library default **0.3**). After zoom, “only some of the page is clear” is tile cache eviction / progressive re-render. |
| iOS | PDFKit | Vector; should stay sharp. Risk is Flutter platform view stuck at 1× `contentScaleFactor`. |

True supersampling (render at 1.5–2× and downscale) would multiply bitmap memory and needs a different engine/fork — **not** enabled by default.

### Changes

**Android**
- Apply Dart defaults when creation params omit quality flags (`useBestQuality`, `enableAntialiasing`, `enableRenderDuringScale` → `true`).
- When `thumbnailRatio` is omitted, set `Constants.THUMBNAIL_RATIO = 0.8` (Dart default) instead of leaving the library’s soft 0.3.
- Density-aware page-part / thumbnail cache sizes (raise only, capped: e.g. 150/10 @2×, 180/12 @2.5×, 200/16 @3.5×) to reduce blurry tiles after zoom without 2× bitmaps.

**iOS**
- Pin `contentScaleFactor` / layer `contentsScale` to the screen scale on init, `didMoveToWindow`, and layout.

**Docs**
- README options table + “Render quality” section (knobs, costs, hard Pdfium limits, `thumbnailRatio: 1.0` tip).
- Dart API docs for the Android quality fields.
- CHANGELOG under **Unreleased**.

### Tests
- `flutter pub get && dart format . && flutter analyze && flutter test` — all passed (93 tests).
- Android unit tests (`scripts/run_android_unit_tests.sh`) — **84** passed, including new `FlutterPDFViewQualityDefaultsTest`.

### Remaining / not in this PR
- Spatial supersampling or engine swap (MuPDF / `PdfRenderer` at higher scale) — memory tradeoff; left for a future opt-in if needed.
- Do not merge until coordinator stacks into the 1.5.0 beta line.