### PR TITLE
fix: page alignment top option + Android setPage center (#250, #272, #197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ Native language migration on both platforms. Includes everything in `1.4.5`.
 - Fix a platform-view remount race: late creation callbacks from a disposed or remounted view can no
   longer complete the new controller with a stale instance
 - Harden iOS `setZoomLimits` and align the podspec `swift_version`
-- No public Dart API changes
+- Add `PageAlignment` (`center` default, `top`) so short / single-page documents can pin to the top of
+  the viewport instead of being vertically centered ([#250](https://github.com/endigo/flutter_pdfview/issues/250),
+  [#272](https://github.com/endigo/flutter_pdfview/issues/272)); iOS page-break margins put free space
+  below the page when top-aligned
+- Fix Android `setPage` / `jumpTo` leaving pages left-aligned on the secondary axis — re-center
+  horizontally after page changes ([#197](https://github.com/endigo/flutter_pdfview/issues/197))
 
 ## 1.4.5
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 | filePath              |   ✅    | ✅  |                   |
 | pdfData               |   ✅    | ✅  |                   |
 | fitPolicy             |   ✅    | ✅  | `FitPolicy.WIDTH` |
+| pageAlignment*        |   ✅    | ✅  | `PageAlignment.center` |
 | enableSwipe           |   ✅    | ✅  |      `true`       |
 | swipeHorizontal       |   ✅    | ✅  |      `false`      |
 | password              |   ✅    | ✅  |      `null`       |
@@ -83,6 +84,15 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 Notes:
 - `showScrollIndicators` is ignored on iOS while horizontal page-flipping is active (`pageFling: true` together with `swipeHorizontal: true`).
 - `autoSpacing` only adds gaps between pages. It does not change initial zoom or `fitPolicy` (fixed in [#150](https://github.com/endigo/flutter_pdfview/issues/150)).
+- `pageAlignment` controls where a document that is **shorter than the viewport** sits. The default `PageAlignment.center` matches historical AndroidPdfViewer / PDFKit behavior. Use `PageAlignment.top` so free space is below the page (typical for single-page PDFs — [#250](https://github.com/endigo/flutter_pdfview/issues/250), [#272](https://github.com/endigo/flutter_pdfview/issues/272)):
+
+```dart
+PDFView(
+  filePath: path,
+  pageAlignment: PageAlignment.top,
+  backgroundColor: Colors.grey.shade200,
+)
+```
 
 ### Using PDFView inside a scrollable widget
 

--- a/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
+++ b/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
@@ -44,6 +44,9 @@ class FlutterPDFView(
     private val displayDensity: Float
     private val mainHandler = Handler(Looper.getMainLooper())
 
+    /** Creation / runtime page alignment (#250, #272). Default centers short docs. */
+    private var pageAlignment: PageAlignment = getPageAlignment(params)
+
     @Volatile
     private var disposed = false
 
@@ -141,12 +144,20 @@ class FlutterPDFView(
         }
 
         if (config != null) {
+            // PageAlignment.top disables AndroidPdfViewer's autoSpacing "center each
+            // page in the viewport" pads (#250). Keep a small fixed gap when the user
+            // still asked for spacing between multi-page documents.
+            val userAutoSpacing = getBoolean(params, "autoSpacing")
+            val topAlign = pageAlignment == PageAlignment.TOP
+            val effectiveAutoSpacing = userAutoSpacing && !topAlign
+            val interPageSpacingDp = if (topAlign && userAutoSpacing) TOP_ALIGN_SPACING_DP else 0
             config
                 .enableSwipe(getBoolean(params, "enableSwipe"))
                 .swipeHorizontal(getBoolean(params, "swipeHorizontal"))
                 .password(getString(params, "password"))
                 .nightMode(getBoolean(params, "nightMode"))
-                .autoSpacing(getBoolean(params, "autoSpacing"))
+                .autoSpacing(effectiveAutoSpacing)
+                .spacing(interPageSpacingDp)
                 .pageFling(getBoolean(params, "pageFling"))
                 .pageSnap(getBoolean(params, "pageSnap"))
                 .pageFitPolicy(getFitPolicy(params))
@@ -178,6 +189,13 @@ class FlutterPDFView(
                     methodChannel.invokeMethod("onPageError", args)
                 }.onRender { pages ->
                     if (disposed) return@onRender
+                    // After first layout, pin short docs to top and re-center
+                    // the secondary axis for defaultPage / setPage parity (#197, #250).
+                    view.post {
+                        if (!disposed && pdfView != null) {
+                            applyPagePlacement(view)
+                        }
+                    }
                     val args: MutableMap<String, Any> = HashMap()
                     args["pages"] = pages
                     methodChannel.invokeMethod("onRender", args)
@@ -433,6 +451,10 @@ class FlutterPDFView(
             }
             try {
                 current.jumpTo(page)
+                // #197: jumpTo keeps the previous secondary-axis offset, so after
+                // a pan/zoom the new page can sit left-aligned. Re-center X (or Y
+                // in horizontal mode) and re-apply PageAlignment.top when needed.
+                applyPagePlacement(current)
                 current.loadPages()
                 current.invalidate()
                 result.success(true)
@@ -446,6 +468,109 @@ class FlutterPDFView(
         } else {
             mainHandler.post(jump)
         }
+    }
+
+    /**
+     * Re-centers the secondary axis (#197) and optionally pins the primary axis
+     * to the start for [PageAlignment.TOP] when the document is shorter than the
+     * viewport (#250, #272).
+     *
+     * AndroidPdfViewer's [PDFView.moveTo] always vertical-centers short
+     * documents and [PDFView.jumpTo] preserves the previous X offset, so we
+     * recompute offsets here after load / setPage.
+     */
+    private fun applyPagePlacement(view: PDFView) {
+        if (disposed || view.pageCount <= 0 || view.width <= 0 || view.height <= 0) {
+            return
+        }
+        try {
+            // Preserve the primary-axis offset from jumpTo / current scroll; only
+            // recompute the secondary axis (#197). For short docs + TOP, force
+            // primary to 0 after moveTo undoes library vertical-centering (#250).
+            val secondary = centeredSecondaryOffset(view)
+            if (view.isSwipeVertical) {
+                view.moveTo(secondary, view.currentYOffset)
+                if (pageAlignment == PageAlignment.TOP) {
+                    forcePrimaryOffsetIfShort(view, isVertical = true)
+                }
+            } else {
+                view.moveTo(view.currentXOffset, secondary)
+                if (pageAlignment == PageAlignment.TOP) {
+                    forcePrimaryOffsetIfShort(view, isVertical = false)
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "applyPagePlacement", e)
+        }
+    }
+
+    /**
+     * Offset that centers the max-page strip on the secondary axis (X when
+     * swiping vertically, Y when swiping horizontally).
+     */
+    private fun centeredSecondaryOffset(view: PDFView): Float {
+        val pageCount = view.pageCount
+        if (pageCount <= 0) {
+            return 0f
+        }
+        var maxSecondary = 0f
+        for (i in 0 until pageCount) {
+            val size = view.getPageSize(i) ?: continue
+            val dim = if (view.isSwipeVertical) size.width else size.height
+            if (dim > maxSecondary) {
+                maxSecondary = dim
+            }
+        }
+        val scaled = view.toCurrentScale(maxSecondary)
+        return if (view.isSwipeVertical) {
+            centerSecondaryOffset(view.width.toFloat(), scaled)
+        } else {
+            centerSecondaryOffset(view.height.toFloat(), scaled)
+        }
+    }
+
+    /**
+     * [PDFView.moveTo] overwrites the primary offset when content fits the
+     * viewport (centers it). For [PageAlignment.TOP] we write 0 after moveTo so
+     * free space sits below / after the content.
+     */
+    private fun forcePrimaryOffsetIfShort(view: PDFView, isVertical: Boolean) {
+        if (!documentFitsAlongPrimary(view, isVertical)) {
+            return
+        }
+        try {
+            val fieldName = if (isVertical) "currentYOffset" else "currentXOffset"
+            val field = PDFView::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            field.setFloat(view, 0f)
+            view.loadPages()
+            view.invalidate()
+        } catch (e: Exception) {
+            Log.w(TAG, "forcePrimaryOffsetIfShort", e)
+        }
+    }
+
+    /** True when the tight document length is smaller than the viewport. */
+    private fun documentFitsAlongPrimary(view: PDFView, isVertical: Boolean): Boolean {
+        val pageCount = view.pageCount
+        if (pageCount <= 0) {
+            return true
+        }
+        var length = 0f
+        val spacingPx = view.spacingPx.toFloat() * view.zoom
+        for (i in 0 until pageCount) {
+            val size = view.getPageSize(i) ?: continue
+            length += if (isVertical) {
+                view.toCurrentScale(size.height)
+            } else {
+                view.toCurrentScale(size.width)
+            }
+            if (i < pageCount - 1) {
+                length += spacingPx
+            }
+        }
+        val viewport = if (isVertical) view.height.toFloat() else view.width.toFloat()
+        return length < viewport - 1f
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -474,6 +599,15 @@ class FlutterPDFView(
                 "preventLinkNavigation" -> {
                     val plh = this.linkHandler as PDFLinkHandler
                     plh.setPreventLinkNavigation(getBoolean(settings, key))
+                }
+                "pageAlignment" -> {
+                    pageAlignment = getPageAlignment(settings)
+                    // Re-apply offsets; full autoSpacing flip needs a remount.
+                    view.post {
+                        if (!disposed && pdfView != null) {
+                            applyPagePlacement(view)
+                        }
+                    }
                 }
                 "maxZoom" -> view.maxZoom = getFloat(settings, key, DEFAULT_MAX_ZOOM)
                 "minZoom" -> view.minZoom = getFloat(settings, key, DEFAULT_MIN_ZOOM)
@@ -528,12 +662,20 @@ class FlutterPDFView(
         }
     }
 
+    /** Dart [PageAlignment] mirrored for creation-param parsing. */
+    enum class PageAlignment {
+        CENTER,
+        TOP,
+    }
+
     companion object {
         const val TAG = "FlutterPDFView"
 
         private const val DEFAULT_MAX_ZOOM = 4.0f
         private const val DEFAULT_MIN_ZOOM = 1.0f
         private const val DRAW_THROTTLE_MS = 16L // ~1 frame at 60fps
+        /** Fixed inter-page gap (dp) when top-align disables autoSpacing but user wants gaps. */
+        private const val TOP_ALIGN_SPACING_DP = 8
 
         @JvmStatic
         @VisibleForTesting
@@ -541,6 +683,25 @@ class FlutterPDFView(
             val keyObj = params[key] as Boolean?
             val bKey: Boolean = keyObj ?: false
             return params.containsKey(key) && bKey
+        }
+
+        @JvmStatic
+        @VisibleForTesting
+        fun getPageAlignment(params: Map<String, Any?>): PageAlignment {
+            return when (getString(params, "pageAlignment")) {
+                "PageAlignment.top" -> PageAlignment.TOP
+                else -> PageAlignment.CENTER
+            }
+        }
+
+        /**
+         * Secondary-axis offset that centers a [scaledMax] strip in [viewport].
+         * Exposed for unit tests of the #197 centering math.
+         */
+        @JvmStatic
+        @VisibleForTesting
+        fun centerSecondaryOffset(viewport: Float, scaledMax: Float): Float {
+            return (viewport - scaledMax) / 2f
         }
 
         @JvmStatic

--- a/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewParamsTest.java
+++ b/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewParamsTest.java
@@ -186,6 +186,56 @@ public class FlutterPDFViewParamsTest {
         assertEquals(FitPolicy.BOTH, FlutterPDFView.getFitPolicy(empty()));
     }
 
+    // --------------------------------------------------------- getPageAlignment
+
+    @Test
+    public void getPageAlignment_top() {
+        assertEquals(
+                FlutterPDFView.PageAlignment.TOP,
+                FlutterPDFView.getPageAlignment(params("pageAlignment", "PageAlignment.top")));
+    }
+
+    @Test
+    public void getPageAlignment_center() {
+        assertEquals(
+                FlutterPDFView.PageAlignment.CENTER,
+                FlutterPDFView.getPageAlignment(params("pageAlignment", "PageAlignment.center")));
+    }
+
+    @Test
+    public void getPageAlignment_missingKey_defaultsToCenter() {
+        assertEquals(
+                FlutterPDFView.PageAlignment.CENTER,
+                FlutterPDFView.getPageAlignment(empty()));
+    }
+
+    @Test
+    public void getPageAlignment_unknownValue_defaultsToCenter() {
+        assertEquals(
+                FlutterPDFView.PageAlignment.CENTER,
+                FlutterPDFView.getPageAlignment(params("pageAlignment", "PageAlignment.bottom")));
+    }
+
+    /**
+     * #197: secondary-axis centering math used after setPage / jumpTo.
+     * When the page strip is narrower than the viewport the offset is positive
+     * (centered); when wider it is negative (moveTo clamps).
+     */
+    @Test
+    public void centerSecondaryOffset_pageNarrowerThanViewport_isPositive() {
+        assertEquals(50f, FlutterPDFView.centerSecondaryOffset(200f, 100f), 0.001f);
+    }
+
+    @Test
+    public void centerSecondaryOffset_pageEqualsViewport_isZero() {
+        assertEquals(0f, FlutterPDFView.centerSecondaryOffset(200f, 200f), 0.001f);
+    }
+
+    @Test
+    public void centerSecondaryOffset_pageWiderThanViewport_isNegative() {
+        assertEquals(-50f, FlutterPDFView.centerSecondaryOffset(200f, 300f), 0.001f);
+    }
+
     // ---------------------------------------------------- issue #150 independence
 
     /**

--- a/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
+++ b/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
@@ -206,6 +206,12 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
         case both
     }
 
+    /// How short documents sit in free space (mirrors Dart [PageAlignment]).
+    private enum PageAlignment {
+        case center
+        case top
+    }
+
     private weak var controller: PDFViewController?
 
     private let pdfView: PDFView
@@ -227,6 +233,7 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
     private var minScaleFactor: CGFloat = 0
     private var hasSentInitialPage = false
     private var fitPolicy: FitPolicy = .width
+    private var pageAlignment: PageAlignment = .center
     /// Last view size we laid out against — used to re-fit after the temporary
     /// non-zero frame (#268) expands to the real Flutter bounds (#150).
     private var lastLayoutSize: CGSize = .zero
@@ -304,6 +311,7 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
     private func loadDocument(arguments args: [String: Any]?) {
         autoSpacing = args?.bool("autoSpacing") ?? false
         fitPolicy = Self.fitPolicy(fromArguments: args)
+        pageAlignment = Self.pageAlignment(fromArguments: args)
         let pageFling = args?.bool("pageFling") ?? false
         let enableSwipe = args?.bool("enableSwipe") ?? false
         preventLinkNavigation = args?.bool("preventLinkNavigation") ?? false
@@ -359,9 +367,15 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
             ? .singlePageContinuous
             : .singlePage
         // autoSpacing only controls gaps between pages — never zoom/fit (#150).
+        // With PageAlignment.top, put the break margin only after each page so
+        // free space (and gaps) sit below rather than sandwiching the page (#272).
         pdfView.displaysPageBreaks = autoSpacing
         if autoSpacing {
-            pdfView.pageBreakMargins = UIEdgeInsets(top: 4, left: 0, bottom: 4, right: 0)
+            if pageAlignment == .top {
+                pdfView.pageBreakMargins = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
+            } else {
+                pdfView.pageBreakMargins = UIEdgeInsets(top: 4, left: 0, bottom: 4, right: 0)
+            }
         } else {
             pdfView.pageBreakMargins = .zero
         }
@@ -729,7 +743,69 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
                 ]
             )
         }
+
+        // After scale/layout, pin short documents to the top when requested
+        // (#250, #272). PDFKit centers by default.
+        if pageAlignment == .top {
+            pinContentToTop(animated: false)
+        }
         return true
+    }
+
+    /// Parses Dart's `PageAlignment.center|top` creation argument.
+    private static func pageAlignment(fromArguments args: [String: Any]?) -> PageAlignment {
+        guard let raw = args?["pageAlignment"] as? String else { return .center }
+        switch raw {
+        case "PageAlignment.top":
+            return .top
+        default:
+            return .center
+        }
+    }
+
+    /// Pins the visible page to the top of the viewport and removes the
+    /// vertical centering inset PDFKit applies when content is shorter than
+    /// the view (#250, #272).
+    private func pinContentToTop(animated: Bool) {
+        guard let page = pdfView.currentPage ?? defaultPage else { return }
+
+        // Navigate to the top edge of the page (PDF coords: origin bottom-left).
+        let pageBounds = page.bounds(for: pdfView.displayBox)
+        let topRect = CGRect(
+            x: 0,
+            y: max(pageBounds.maxY - 1, pageBounds.minY),
+            width: max(1, min(1, pageBounds.width)),
+            height: max(1, min(1, pageBounds.height))
+        )
+        pdfView.go(to: topRect, on: page)
+
+        guard let scrollView else { return }
+
+        // If the document is shorter than the viewport, PDFKit centers it via
+        // content offset / insets. Force free space below the page.
+        let contentHeight = scrollView.contentSize.height
+        let viewHeight = scrollView.bounds.height
+        if contentHeight > 0, contentHeight < viewHeight - 0.5 {
+            let extra = viewHeight - contentHeight
+            var inset = scrollView.contentInset
+            // Keep horizontal insets untouched; put leftover height at the bottom.
+            inset.top = 0
+            inset.bottom = max(inset.bottom, extra)
+            scrollView.contentInset = inset
+            let topY = -scrollView.adjustedContentInset.top
+            let offset = CGPoint(x: scrollView.contentOffset.x, y: topY)
+            scrollView.setContentOffset(offset, animated: animated)
+        } else {
+            // Tall document: still ensure we are at the top of the current page
+            // destination (go(to:) above), without rewriting insets.
+            let topY = -scrollView.adjustedContentInset.top
+            if scrollView.contentOffset.y < topY - 0.5 {
+                scrollView.setContentOffset(
+                    CGPoint(x: scrollView.contentOffset.x, y: topY),
+                    animated: animated
+                )
+            }
+        }
     }
 
     func view() -> UIView {
@@ -882,10 +958,34 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate,
         }
 
         pdfView.go(to: page)
+        if pageAlignment == .top {
+            pinContentToTop(animated: false)
+        }
         result(NSNumber(value: true))
     }
 
-    func onUpdateSettings(_: FlutterMethodCall, result: FlutterResult) {
+    func onUpdateSettings(_ call: FlutterMethodCall, result: FlutterResult) {
+        let settings = call.arguments as? [String: Any]
+        if settings?["pageAlignment"] != nil {
+            pageAlignment = Self.pageAlignment(fromArguments: settings)
+            // Update page-break margins to match top vs center (#272 gaps).
+            if autoSpacing {
+                if pageAlignment == .top {
+                    pdfView.pageBreakMargins = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
+                } else {
+                    pdfView.pageBreakMargins = UIEdgeInsets(top: 4, left: 0, bottom: 4, right: 0)
+                }
+            }
+            if pageAlignment == .top {
+                pinContentToTop(animated: false)
+            } else if let scrollView {
+                // Restore default centering: clear the bottom pad we may have added.
+                var inset = scrollView.contentInset
+                inset.bottom = 0
+                scrollView.contentInset = inset
+            }
+            setNeedsLayout()
+        }
         result(nil)
     }
 

--- a/lib/flutter_pdfview.dart
+++ b/lib/flutter_pdfview.dart
@@ -10,6 +10,7 @@
 /// PDFView(
 ///   filePath: path,
 ///   fitPolicy: FitPolicy.BOTH,
+///   pageAlignment: PageAlignment.top, // optional; default centers short docs
 ///   onViewCreated: (PDFViewController controller) async {
 ///     final int? pages = await controller.getPageCount();
 ///     await controller.setPage(0);

--- a/lib/src/pdf_view.dart
+++ b/lib/src/pdf_view.dart
@@ -43,6 +43,7 @@ class PDFView extends StatefulWidget {
     this.fitEachPage = true,
     this.defaultPage = 0,
     this.fitPolicy = FitPolicy.WIDTH,
+    this.pageAlignment = PageAlignment.center,
     this.preventLinkNavigation = false,
     this.backgroundColor,
     this.maxZoom = 4.0,
@@ -159,6 +160,16 @@ class PDFView extends StatefulWidget {
   ///
   /// Supported on Android and iOS.
   final FitPolicy fitPolicy;
+
+  /// How a document that is shorter than the viewport is placed inside it.
+  ///
+  /// Defaults to [PageAlignment.center] (historical behavior of AndroidPdfViewer
+  /// and PDFKit). Use [PageAlignment.top] so free space sits below the page —
+  /// typical for single-page PDFs ([#250](https://github.com/endigo/flutter_pdfview/issues/250),
+  /// [#272](https://github.com/endigo/flutter_pdfview/issues/272)).
+  ///
+  /// Supported on Android and iOS.
+  final PageAlignment pageAlignment;
 
   /// Whether each page is fitted individually.
   @Deprecated('will be removed next version')

--- a/lib/src/pdf_view_settings.dart
+++ b/lib/src/pdf_view_settings.dart
@@ -21,6 +21,7 @@ class _PDFViewSettings {
     this.thumbnailRatio,
     this.defaultPage,
     this.fitPolicy,
+    this.pageAlignment,
     this.preventLinkNavigation,
     this.backgroundColor,
     this.maxZoom,
@@ -43,6 +44,7 @@ class _PDFViewSettings {
       thumbnailRatio: widget.thumbnailRatio,
       defaultPage: widget.defaultPage,
       fitPolicy: widget.fitPolicy,
+      pageAlignment: widget.pageAlignment,
       preventLinkNavigation: widget.preventLinkNavigation,
       backgroundColor: widget.backgroundColor,
       maxZoom: widget.maxZoom,
@@ -64,6 +66,7 @@ class _PDFViewSettings {
   final double? thumbnailRatio;
   final int? defaultPage;
   final FitPolicy? fitPolicy;
+  final PageAlignment? pageAlignment;
   final bool? preventLinkNavigation;
 
   final Color? backgroundColor;
@@ -87,6 +90,7 @@ class _PDFViewSettings {
       'thumbnailRatio': thumbnailRatio,
       'defaultPage': defaultPage,
       'fitPolicy': fitPolicy.toString(),
+      'pageAlignment': pageAlignment.toString(),
       'preventLinkNavigation': preventLinkNavigation,
       'backgroundColor': backgroundColor?.toARGB32(),
       'maxZoom': maxZoom,
@@ -114,6 +118,9 @@ class _PDFViewSettings {
     }
     if (preventLinkNavigation != newSettings.preventLinkNavigation) {
       updates['preventLinkNavigation'] = newSettings.preventLinkNavigation;
+    }
+    if (pageAlignment != newSettings.pageAlignment) {
+      updates['pageAlignment'] = newSettings.pageAlignment.toString();
     }
     if (maxZoom != newSettings.maxZoom) {
       updates['maxZoom'] = newSettings.maxZoom;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -50,3 +50,17 @@ enum FitPolicy {
   /// Scales each page so that it fits entirely inside the viewport.
   BOTH,
 }
+
+/// How a document that is shorter than the viewport is placed inside it.
+///
+/// AndroidPdfViewer and PDFKit both center short documents by default. Use
+/// [top] when free space should sit below the page (single-page PDFs, forms).
+/// See [#250](https://github.com/endigo/flutter_pdfview/issues/250) and
+/// [#272](https://github.com/endigo/flutter_pdfview/issues/272).
+enum PageAlignment {
+  /// Center the document in free space (historical default).
+  center,
+
+  /// Pin the document to the top of the viewport; free space is below.
+  top,
+}

--- a/test/creation_params_test.dart
+++ b/test/creation_params_test.dart
@@ -22,6 +22,7 @@ const Set<String> _expectedKeys = <String>{
   'thumbnailRatio',
   'defaultPage',
   'fitPolicy',
+  'pageAlignment',
   'preventLinkNavigation',
   'backgroundColor',
   'maxZoom',
@@ -137,6 +138,7 @@ void main() {
       expect(params['thumbnailRatio'], 0.8);
       expect(params['defaultPage'], 0);
       expect(params['fitPolicy'], 'FitPolicy.WIDTH');
+      expect(params['pageAlignment'], 'PageAlignment.center');
       expect(params['preventLinkNavigation'], isFalse);
       expect(params['maxZoom'], 4.0);
       expect(params['minZoom'], 1.0);
@@ -161,6 +163,7 @@ void main() {
           thumbnailRatio: 0.5,
           defaultPage: 3,
           fitPolicy: FitPolicy.HEIGHT,
+          pageAlignment: PageAlignment.top,
           preventLinkNavigation: true,
           backgroundColor: Color(0xFF112233),
           maxZoom: 8.0,
@@ -183,10 +186,27 @@ void main() {
       expect(params['thumbnailRatio'], 0.5);
       expect(params['defaultPage'], 3);
       expect(params['fitPolicy'], 'FitPolicy.HEIGHT');
+      expect(params['pageAlignment'], 'PageAlignment.top');
       expect(params['preventLinkNavigation'], isTrue);
       expect(params['backgroundColor'], 0xFF112233);
       expect(params['maxZoom'], 8.0);
       expect(params['minZoom'], 0.5);
+    }, variant: _iOS);
+
+    testWidgets('serializes PageAlignment.center', (WidgetTester tester) async {
+      final Map<Object?, Object?> params = await pumpAndCapture(
+        tester,
+        const PDFView(filePath: 'a.pdf', pageAlignment: PageAlignment.center),
+      );
+      expect(params['pageAlignment'], 'PageAlignment.center');
+    }, variant: _iOS);
+
+    testWidgets('serializes PageAlignment.top', (WidgetTester tester) async {
+      final Map<Object?, Object?> params = await pumpAndCapture(
+        tester,
+        const PDFView(filePath: 'a.pdf', pageAlignment: PageAlignment.top),
+      );
+      expect(params['pageAlignment'], 'PageAlignment.top');
     }, variant: _iOS);
 
     testWidgets('serializes FitPolicy.BOTH', (WidgetTester tester) async {

--- a/test/flutter_pdfview_test.dart
+++ b/test/flutter_pdfview_test.dart
@@ -120,6 +120,14 @@ void main() {
       expect(bothFit.fitPolicy, FitPolicy.BOTH);
     });
 
+    test('PDFView with pageAlignment options', () {
+      final centered = PDFView(filePath: 'test.pdf');
+      expect(centered.pageAlignment, PageAlignment.center);
+
+      final top = PDFView(filePath: 'test.pdf', pageAlignment: PageAlignment.top);
+      expect(top.pageAlignment, PageAlignment.top);
+    });
+
     test('PDFView with different navigation settings', () {
       final customPdfView = PDFView(
         filePath: 'test.pdf',

--- a/test/page_alignment_test.dart
+++ b/test/page_alignment_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/foundation.dart' show TargetPlatform;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_pdfview/flutter_pdfview.dart';
+
+/// Regression coverage for [#250](https://github.com/endigo/flutter_pdfview/issues/250),
+/// [#272](https://github.com/endigo/flutter_pdfview/issues/272) (top alignment) and the
+/// Dart side of the setPage placement surface used by
+/// [#197](https://github.com/endigo/flutter_pdfview/issues/197).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final TargetPlatformVariant iOS = TargetPlatformVariant.only(TargetPlatform.iOS);
+
+  late List<Map<Object?, Object?>> created;
+  late List<int> viewIds;
+  late List<MethodCall> viewCalls;
+
+  setUp(() {
+    created = <Map<Object?, Object?>>[];
+    viewIds = <int>[];
+    viewCalls = <MethodCall>[];
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform_views,
+      (MethodCall call) async {
+        if (call.method != 'create') {
+          return null;
+        }
+        final Map<Object?, Object?> args = call.arguments as Map<Object?, Object?>;
+        final int id = args['id']! as int;
+        viewIds.add(id);
+
+        final Uint8List? raw = args['params'] as Uint8List?;
+        if (raw != null) {
+          created.add(
+            const StandardMessageCodec().decodeMessage(
+                  ByteData.view(raw.buffer, raw.offsetInBytes, raw.lengthInBytes),
+                )!
+                as Map<Object?, Object?>,
+          );
+        }
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+          MethodChannel('plugins.endigo.io/pdfview_$id'),
+          (MethodCall viewCall) async {
+            viewCalls.add(viewCall);
+            return null;
+          },
+        );
+        return 0;
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform_views,
+      null,
+    );
+    for (final int id in viewIds) {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        MethodChannel('plugins.endigo.io/pdfview_$id'),
+        null,
+      );
+    }
+  });
+
+  group('PageAlignment API', () {
+    test('defaults to center', () {
+      const PDFView view = PDFView(filePath: 'a.pdf');
+      expect(view.pageAlignment, PageAlignment.center);
+    });
+
+    test('accepts top', () {
+      const PDFView view = PDFView(filePath: 'a.pdf', pageAlignment: PageAlignment.top);
+      expect(view.pageAlignment, PageAlignment.top);
+    });
+
+    test('enum toString matches native wire format', () {
+      // Native Kotlin/Swift switch on these exact strings.
+      expect(PageAlignment.center.toString(), 'PageAlignment.center');
+      expect(PageAlignment.top.toString(), 'PageAlignment.top');
+    });
+  });
+
+  group('PageAlignment creation params', () {
+    testWidgets('default serializes PageAlignment.center', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: PDFView(filePath: 'a.pdf')),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(created, hasLength(1));
+      expect(created.single['pageAlignment'], 'PageAlignment.center');
+    }, variant: iOS);
+
+    testWidgets('top serializes PageAlignment.top', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PDFView(filePath: 'a.pdf', pageAlignment: PageAlignment.top),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(created, hasLength(1));
+      expect(created.single['pageAlignment'], 'PageAlignment.top');
+      // Independent of fitPolicy / autoSpacing (#150 style independence).
+      expect(created.single['fitPolicy'], 'FitPolicy.WIDTH');
+      expect(created.single['autoSpacing'], isTrue);
+    }, variant: iOS);
+
+    testWidgets('pageAlignment is independent of fitPolicy and autoSpacing', (
+      WidgetTester tester,
+    ) async {
+      // Remount with a unique document path each time so the platform view is
+      // recreated (settings-only changes only send updateSettings).
+      var index = 0;
+      for (final PageAlignment align in PageAlignment.values) {
+        for (final FitPolicy policy in FitPolicy.values) {
+          for (final bool autoSpacing in <bool>[true, false]) {
+            created.clear();
+            final String path = 'doc_${index++}.pdf';
+            await tester.pumpWidget(
+              MaterialApp(
+                home: Scaffold(
+                  body: PDFView(
+                    filePath: path,
+                    pageAlignment: align,
+                    fitPolicy: policy,
+                    autoSpacing: autoSpacing,
+                  ),
+                ),
+              ),
+            );
+            await tester.pumpAndSettle();
+            expect(created, hasLength(1), reason: 'path=$path');
+            expect(
+              created.single['pageAlignment'],
+              align.toString(),
+              reason: 'align=$align policy=$policy autoSpacing=$autoSpacing',
+            );
+            expect(created.single['fitPolicy'], policy.toString());
+            expect(created.single['autoSpacing'], autoSpacing);
+          }
+        }
+      }
+    }, variant: iOS);
+
+    testWidgets('changing pageAlignment pushes updateSettings', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PDFView(filePath: 'a.pdf', pageAlignment: PageAlignment.center),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      viewCalls.clear();
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PDFView(filePath: 'a.pdf', pageAlignment: PageAlignment.top),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(viewCalls.map((MethodCall c) => c.method), <String>['updateSettings']);
+      expect(viewCalls.single.arguments, <String, Object?>{'pageAlignment': 'PageAlignment.top'});
+    }, variant: iOS);
+  });
+}


### PR DESCRIPTION
## Summary

- Add additive `PageAlignment` API (`center` default, `top`) so short/single-page PDFs can pin to the top of the viewport instead of being vertically centered ([#250](https://github.com/endigo/flutter_pdfview/issues/250), [#272](https://github.com/endigo/flutter_pdfview/issues/272)).
- **Android (Kotlin)**: after `setPage`/`jumpTo`, re-center the secondary axis so pages are not left-aligned ([#197](https://github.com/endigo/flutter_pdfview/issues/197)); top alignment disables autoSpacing center-pads and forces primary offset 0 when the document fits the viewport.
- **iOS (Swift)**: pin short content to top via PDF destination + scroll insets; page-break margins put free space below when top-aligned (background color was already fixed earlier).
- No package version bump (coordinator releases `1.5.0-beta.N`).

## Usage

```dart
PDFView(
  filePath: path,
  pageAlignment: PageAlignment.top,
  backgroundColor: Colors.grey.shade200,
)
```

## Test plan

- [x] `flutter pub get && dart format . && flutter analyze && flutter test` — all passed
- [x] Android unit tests (`scripts/run_android_unit_tests.sh`) — all passed (incl. `getPageAlignment` + `centerSecondaryOffset`)
- [ ] Manual: single-page PDF with `PageAlignment.top` on Android/iOS — free space below
- [ ] Manual: multi-page `setPage` on Android — page remains horizontally centered