### PR TITLE
feat: text layer — search, selection, copy control (1.5.0-beta.13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,23 +136,30 @@ is `publish_to: none`. The `Publish to pub.dev` GitHub workflow already sets
 2. Platform view is created via `plugins.endigo.io/pdfview` channel
 3. Native implementation renders PDF and sends callbacks via method channel
 4. Events flow back to Flutter: `onRender`, `onPageChanged`, `onError`, `onTap`,
-   `onPasswordRequired`, etc.
+   `onPasswordRequired`, `onTextSelectionChanged`, `onSearchResultChanged`, etc.
 
 ### Key Features
 
 - **File Loading**: From file path or binary data (Uint8List)
-- **Navigation**: Page navigation, swipe gestures, horizontal/vertical scrolling, page alignment
+- **Navigation**: Page navigation (optional Android `setPage(withAnimation:)`), swipe,
+  horizontal/vertical scrolling, page alignment, optional inter-page `spacing`
 - **Rendering Options**: Color mode (light/dark/system), auto-spacing, page snap, fit policies
 - **Security**: Password-protected PDF support with `onPasswordRequired` / `unlock()`
-- **Callbacks**: Page change, render complete, error handling, link handling, tap
+- **Text layer (iOS)**: find-in-document (`searchText` / next/previous match), selection,
+  and `enableCopy` to suppress the edit-menu copy path (#137 #285 #108). Android has no text
+  layer yet — `isTextLayerSupported()` is `false` and query methods throw `UnsupportedError`
+  (check first; never treat empty results as “unsupported”)
+- **Callbacks**: Page change, render complete, error handling, link handling, tap, search /
+  selection (iOS)
 - **Controller Methods**: `getPageCount()`, `getCurrentPage()`, `setPage()`, `setZoomLimits()`,
-  `getScreenshot()`, `unlock()`
+  `getScreenshot()`, `unlock()`, plus text-layer methods when supported
 
 ## Platform-Specific Considerations
 
 ### iOS
 - Minimum iOS version: 13.0 (as of v1.4.5)
 - Swift 5.9; verified against both Swift Package Manager and CocoaPods
+- PDFKit text layer: search highlights, selection, copy control
 - Platform-view compositing limits apply: `ColorFiltered` / `ShaderMask` / `BackdropFilter`
   ancestors do not affect the native view (see #213)
 
@@ -161,21 +168,27 @@ is `publish_to: none`. The `Publish to pub.dev` GitHub workflow already sets
 - Kotlin, KGP 2.0.0, JVM target 17
 - True hybrid composition (`initExpensiveAndroidView`)
 - Uses AndroidX libraries; ProGuard rules included for release builds
+- Text search/selection not implemented (Pdfium `FPDFText_*` needs a JNI shim; see README
+  “Text layer”)
 
 ## Testing Approach
 
 Dart tests live in `test/` and cover creation params, settings diffing, fit/scale math, page
 alignment, password handling, and the controller. The platform interface has its own suite under
-`packages/flutter_pdfview_platform_interface/test/` covering the wire format, the token check, and
-the method-channel controller. `melos run test` runs both.
+`packages/flutter_pdfview_platform_interface/test/` covering the wire format, the token check,
+the method-channel controller, and text-layer method-channel decoding
+(`test/text_layer_test.dart`). `melos run test` runs both.
 
 Android has a Robolectric/JUnit suite run via `melos run test:android` (wraps
-`scripts/run_android_unit_tests.sh`). Keep it green.
+`scripts/run_android_unit_tests.sh`), including `FlutterPDFViewTextLayerTest` for the
+unsupported-path codes. Keep it green.
 
-`example/integration_test/` drives the real native viewers end to end.
+`example/integration_test/` drives the real native viewers end to end (`password_test.dart`,
+`text_layer_test.dart`). Text fixtures: `scripts/make_text_pdf.py` → `assets/demo-text.pdf`.
 
 The example app (`example/lib/main.dart`) provides comprehensive testing scenarios:
 - Loading from assets and from URL
+- Text search / selection / copy toggles (`TextSearchScreen` + `demo-text.pdf`)
 - Corrupted PDF handling
 - Landscape PDF rendering
 - PDF with links

--- a/packages/flutter_pdfview/CHANGELOG.md
+++ b/packages/flutter_pdfview/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 1.5.0-beta.13
+
+- Add the **text layer**: find-in-document
+  ([#137](https://github.com/endigo/flutter_pdfview/issues/137)), text selection
+  ([#285](https://github.com/endigo/flutter_pdfview/issues/285)) and the ability to stop text
+  being copied out ([#108](https://github.com/endigo/flutter_pdfview/issues/108))
+- New on `PDFViewController`: `searchText`, `nextMatch`, `previousMatch`, `setCurrentMatch`,
+  `clearSearch`, `getSelectedText`, `clearSelection`, and `isTextLayerSupported`
+- New on `PDFView`: `enableTextSelection` and `enableCopy` (both default `true`, both update at
+  runtime without remounting), plus the `onTextSelectionChanged` and `onSearchResultChanged`
+  callbacks
+- **iOS**: implemented on PDFKit — `findString` with every match highlighted, the active one
+  scrolled into view, wrapping navigation, and an edit menu that drops copy / share / look-up
+  when `enableCopy` is `false`
+- **Android**: there is no text layer. AndroidPdfViewer's `PdfiumCore` binds none of Pdfium's
+  `FPDFText_*` API in Java, even though the bundled `libpdfium` exports those symbols natively;
+  reaching them needs a JNI shim this plugin does not ship yet. The query methods therefore
+  **throw `UnsupportedError`** rather than returning an empty list, which would be
+  indistinguishable from "this document contains no matches" and would let apps ship broken
+  search unnoticed. Check `isTextLayerSupported()` before offering search or selection UI.
+  `clearSearch` and `clearSelection` remain no-ops everywhere
+- Adds `example/integration_test/text_layer_test.dart`, which drives the real native viewer, and
+  a deterministic text fixture (`scripts/make_text_pdf.py`)
+- Depends on `flutter_pdfview_platform_interface` ^1.1.0
+- Includes everything in `1.5.0-beta.12`
+
 ## 1.5.0-beta.12
 
 - Add optional `withAnimation` to `PDFViewController.setPage` ([#251](https://github.com/endigo/flutter_pdfview/pull/251)):

--- a/packages/flutter_pdfview/CHANGELOG.md
+++ b/packages/flutter_pdfview/CHANGELOG.md
@@ -21,6 +21,10 @@
   `clearSearch` and `clearSelection` remain no-ops everywhere
 - Adds `example/integration_test/text_layer_test.dart`, which drives the real native viewer, and
   a deterministic text fixture (`scripts/make_text_pdf.py`)
+- Example app: **Search Text in PDF** home action + `TextSearchScreen` (gate on
+  `isTextLayerSupported`, search/next/prev, selection and copy chips)
+- Docs: package README text-layer section and controller table, platform-interface README
+  contract, `Claude.md` features/testing notes, `example/README.md` demo map
 - Depends on `flutter_pdfview_platform_interface` ^1.1.0
 - Includes everything in `1.5.0-beta.12`
 

--- a/packages/flutter_pdfview/README.md
+++ b/packages/flutter_pdfview/README.md
@@ -388,6 +388,10 @@ Wrapping `PDFView` itself in `ColorFiltered` will keep painting a solid tint
 
 ## Example
 
+Basic viewer (password, color mode, layout). For **search / selection / copy**, see
+[Text layer](#text-layer) and the example app’s `TextSearchScreen`
+(`packages/flutter_pdfview/example` → **Search Text in PDF**).
+
 ```dart
 PDFView(
   filePath: path,
@@ -398,6 +402,8 @@ PDFView(
   showScrollIndicators: true,
   colorMode: PdfColorMode.system, // follows Theme brightness
   backgroundColor: Theme.of(context).colorScheme.surface,
+  // Optional: inter-page gap when autoSpacing is true (dp / points).
+  // spacing: 12,
   onRender: (_pages) {
     setState(() {
       pages = _pages;
@@ -410,8 +416,10 @@ PDFView(
   onPageError: (page, error) {
     print('$page: ${error.toString()}');
   },
-  onViewCreated: (PDFViewController pdfViewController) {
+  onViewCreated: (PDFViewController pdfViewController) async {
     _controller.complete(pdfViewController);
+    // Android can animate; iOS ignores withAnimation.
+    // await pdfViewController.setPage(2, withAnimation: true);
   },
   onPageChanged: (int page, int total) {
     print('page change: $page/$total');
@@ -425,25 +433,38 @@ PDFView(
 ),
 ```
 
+Text-layer sketch (always gate on support):
+
+```dart
+onViewCreated: (PDFViewController c) async {
+  if (!await c.isTextLayerSupported()) return;
+  final matches = await c.searchText('invoice');
+  // nextMatch / previousMatch / clearSearch …
+},
+onSearchResultChanged: (index, total) { /* highlight chrome */ },
+onTextSelectionChanged: (text) { /* selection chrome */ },
+enableTextSelection: true,
+enableCopy: false, // hide copy/share/look-up in the iOS edit menu
+```
+
 # Dependencies
 
 ### Android
 
-[AndroidPdfViewer](https://github.com/barteksc/AndroidPdfViewer)
+[AndroidPdfViewer](https://github.com/barteksc/AndroidPdfViewer) (via
+`com.github.marain87:AndroidPdfViewer`)
 
-### iOS (only support> 12.0)
+### iOS (13.0+)
 
 [PDFKit](https://developer.apple.com/documentation/pdfkit)
 
 # Future plans
 
-- Replace barteksc/AndroidPdfViewer with MuPDF or Android Native PDF Renderer.
-- Improve documentation
-- Support other platforms such as MacOS, Windows, Linux and Web
-- Add search functionality
-- Improve performance on zooming, page changing
-- Improve image quality
-- Write more test
+- Android text layer (JNI shim over Pdfium `FPDFText_*` already present in the AAR)
+- Replace / augment AndroidPdfViewer with MuPDF or the Android native PDF renderer where useful
+- Support other platforms (macOS, Windows, Linux, Web) via the federated interface
+- Improve performance on zooming and page changes
+- More integration tests and device coverage
 
 # Support
 

--- a/packages/flutter_pdfview/README.md
+++ b/packages/flutter_pdfview/README.md
@@ -20,16 +20,16 @@ dependencies:
 
 #### Trying the 1.5.0 beta
 
-`1.5.0-beta.10` continues the Kotlin/Swift line by letting password-protected
-documents be unlocked from the app ([#274](https://github.com/endigo/flutter_pdfview/issues/274)),
-on top of the luminance-preserving `PdfColorMode` dark theming in `beta.9`
-([#215](https://github.com/endigo/flutter_pdfview/issues/215),
-[#138](https://github.com/endigo/flutter_pdfview/issues/138)). Pre-releases are not
-picked up by a `^` constraint, so pin it explicitly:
+`1.5.0-beta.13` continues the Kotlin/Swift line with a PDFKit **text layer** —
+search, selection, and copy control on iOS ([#137](https://github.com/endigo/flutter_pdfview/issues/137),
+[#285](https://github.com/endigo/flutter_pdfview/issues/285),
+[#108](https://github.com/endigo/flutter_pdfview/issues/108)) — on top of password unlock,
+`PdfColorMode`, spacing, and animated `setPage`. Pre-releases are not picked up by a
+`^` constraint, so pin it explicitly:
 
 ```
 dependencies:
-  flutter_pdfview: 1.5.0-beta.10
+  flutter_pdfview: 1.5.0-beta.13
 ```
 
 Feedback is welcome in [#351](https://github.com/endigo/flutter_pdfview/issues/351).
@@ -65,6 +65,10 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 | onLoadComplete        |   ✅    | ✅  |      `null`       |
 | onDraw                |   ✅    | ✅  |      `null`       |
 | onTap                 |   ✅    | ✅  |      `null`       |
+| onTextSelectionChanged |   ❌    | ✅  |      `null`       |
+| onSearchResultChanged |   ❌    | ✅  |      `null`       |
+| enableTextSelection   |   ⚠️    | ✅  |      `true`       |
+| enableCopy            |   ❌    | ✅  |      `true`       |
 | onError               |   ✅    | ✅  |      `null`       |
 | onPageError           |   ✅    | ❌  |      `null`       |
 | onPasswordRequired    |   ✅    | ✅  |      `null`       |
@@ -94,6 +98,7 @@ import 'package:flutter_pdfview/flutter_pdfview.dart';
 | thumbnailRatio*       |   ✅    | ❌  |        0.8        |
 
 Notes:
+- ⚠️ `enableTextSelection` on Android only suppresses the long-press callback — AndroidPdfViewer has no selection UI to disable. See [Text layer](#text-layer) for why selection and search are iOS-only, and always check `isTextLayerSupported()` before offering that UI.
 - `colorMode` themes page content and the gutter on both platforms. Values: `PdfColorMode.light`, `PdfColorMode.dark`, `PdfColorMode.system` (default). `system` follows the app `Theme` brightness (or platform brightness when no `Theme` is present) and is resolved in Dart before being sent to the native view. Dark mode uses a luminance-preserving inversion (hue kept; photos do not become pure negatives). Live updates apply without remounting the platform view.
 - `nightMode` is **deprecated**. Prefer `colorMode`. When `colorMode` is left at `system` and `nightMode: true`, the resolved mode is `dark`. An explicit `colorMode` always wins.
 - `backgroundColor` can be updated at runtime together with `colorMode`. Setting it back to `null` after a non-null value leaves the previous color on screen.
@@ -225,6 +230,69 @@ password can be retried as often as needed without rebuilding the viewer.
 `onError` still fires alongside `onPasswordRequired`, so viewers written before
 this callback existed keep working.
 
+### Text layer
+
+Text selection ([#285](https://github.com/endigo/flutter_pdfview/issues/285)),
+find-in-document ([#137](https://github.com/endigo/flutter_pdfview/issues/137))
+and blocking copy ([#108](https://github.com/endigo/flutter_pdfview/issues/108))
+all need the document's text layer.
+
+**This is iOS-only today.** PDFKit provides text on iOS. On Android,
+AndroidPdfViewer's `PdfiumCore` binds none of Pdfium's `FPDFText_*` API in Java,
+so there is no text to search or select — even though the bundled `libpdfium`
+does export those symbols natively. Reaching them would require a JNI shim this
+plugin does not yet ship.
+
+**Always branch on `isTextLayerSupported()`.** The query methods throw
+`UnsupportedError` where there is no text layer, deliberately: returning an empty
+list would be indistinguishable from "this document contains no matches", and
+apps would ship broken search without noticing. `clearSearch` and
+`clearSelection` stay no-ops everywhere, because clearing nothing is truthful.
+
+```dart
+late PDFViewController controller;
+
+if (await controller.isTextLayerSupported()) {
+  final List<PdfTextMatch> matches = await controller.searchText('invoice');
+  // The first match is already highlighted and scrolled into view.
+  for (final PdfTextMatch match in matches) {
+    debugPrint('match ${match.matchIndex} on page ${match.pageIndex}: ${match.text}');
+  }
+  await controller.nextMatch();     // wraps at the end
+  await controller.clearSearch();
+} else {
+  // Hide the search UI rather than calling and catching.
+}
+```
+
+Track the active match with `onSearchResultChanged`, and the user's selection
+with `onTextSelectionChanged`:
+
+```dart
+PDFView(
+  filePath: path,
+  onSearchResultChanged: (int index, int total) => ..., // index is -1 when cleared
+  onTextSelectionChanged: (String? text) => ...,        // null when cleared
+)
+```
+
+#### Stopping text from leaving the document (#108)
+
+```dart
+PDFView(
+  filePath: path,
+  enableTextSelection: false, // no long-press selection
+  enableCopy: false,          // no copy / share / look-up in the edit menu
+)
+```
+
+Both update at runtime without remounting the view. `enableCopy` needs a
+selection to suppress, so `enableTextSelection: false` disables copying too.
+On Android, `enableTextSelection: false` only suppresses the long-press callback
+(there is nothing to select either way), and `enableCopy` has no effect. Note
+that neither prevents screenshots, nor a user extracting text from a copy of the
+file obtained elsewhere.
+
 ### Using PDFView inside a scrollable widget
 
 When a `PDFView` is embedded in a scrollable parent (`SingleChildScrollView`,
@@ -309,6 +377,14 @@ Wrapping `PDFView` itself in `ColorFiltered` will keep painting a solid tint
 | setZoomLimits      |                  Set the minimum, maximum and mid bounds of the zoom limits                  | `double minZoom, double midZoom, double maxZoom` |        -         |
 | unlock             |            Reopen the document with a password, for encrypted PDFs ([#274](https://github.com/endigo/flutter_pdfview/issues/274))            |                `String password`                 |  `Future<bool>`  |
 | reload             |                            Reload the PDF document in the PDFView                            |                        -                         |  `Future<bool>`  |
+| isTextLayerSupported | Whether this platform can search/select text — see [Text layer](#text-layer) | - | `Future<bool>` |
+| searchText         | Find every occurrence of a string; activates the first match | `String query, {bool caseSensitive}` | `Future<List<PdfTextMatch>>` |
+| nextMatch          | Activate the next match, wrapping at the end | - | `Future<PdfTextMatch?>` |
+| previousMatch      | Activate the previous match, wrapping at the start | - | `Future<PdfTextMatch?>` |
+| setCurrentMatch    | Activate a match by index | `int index` | `Future<PdfTextMatch?>` |
+| clearSearch        | Clear highlights and forget the last search | - | `Future<void>` |
+| getSelectedText    | The currently selected text, or null | - | `Future<String?>` |
+| clearSelection     | Clear the current text selection | - | `Future<void>` |
 
 ## Example
 

--- a/packages/flutter_pdfview/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
+++ b/packages/flutter_pdfview/android/src/main/kotlin/io/endigo/plugins/pdfviewflutter/FlutterPDFView.kt
@@ -91,6 +91,15 @@ class FlutterPDFView(
     /** Remains attached after load so a late size settle can re-fit (#127). */
     private var sizeSettleListener: View.OnLayoutChangeListener? = null
 
+    /**
+     * Whether long-press is left enabled (#285). AndroidPdfViewer has no
+     * selection UI, so `false` only suppresses the long-press callback — there is
+     * nothing to select either way. `disableLongpress()` is Configurator-only, so
+     * a runtime change takes effect on the next document load.
+     */
+    private var enableTextSelection: Boolean =
+        getBoolean(params, "enableTextSelection", DEFAULT_ENABLE_TEXT_SELECTION)
+
     init {
         val view = PDFView(context, null)
         pdfView = view
@@ -300,6 +309,13 @@ class FlutterPDFView(
                     }
                     false
                 }
+                .apply {
+                    // Nothing to select in 3.2.8; this only stops the long-press
+                    // callback from firing (#108, #285).
+                    if (!enableTextSelection) {
+                        disableLongpress()
+                    }
+                }
                 .onPageChange { page, total ->
                     if (disposed) return@onPageChange
                     val args: MutableMap<String, Any> = HashMap()
@@ -411,8 +427,33 @@ class FlutterPDFView(
             "setPage" -> setPage(methodCall, result)
             "updateSettings" -> updateSettings(methodCall, result)
             "setZoomLimits" -> setZoomLimits(methodCall, result)
+            "isTextLayerSupported" -> result.success(false)
+            // #137 / #285: AndroidPdfViewer 3.2.8 ships a libpdfium that exports
+            // the FPDFText_* family, but PdfiumCore binds none of it in Java, so
+            // there is no text to search or select. Fail loudly rather than
+            // returning an empty result, which an app would read as "this
+            // document contains no matches".
+            "searchText",
+            "nextMatch",
+            "previousMatch",
+            "setCurrentMatch",
+            "getSelectedText" -> textLayerUnsupported(result)
+            // Clearing nothing is a truthful outcome, so these stay no-ops.
+            "clearSearch", "clearSelection" -> result.success(null)
             else -> result.notImplemented()
         }
+    }
+
+    /** Reports that this platform has no text layer at all (#137, #285). */
+    private fun textLayerUnsupported(result: Result) {
+        result.error(
+            TEXT_LAYER_UNSUPPORTED_CODE,
+            "flutter_pdfview has no text layer on Android: AndroidPdfViewer " +
+                "$ANDROID_PDF_VIEWER_VERSION does not bind Pdfium's FPDFText_* API in Java. " +
+                "Check PDFViewController.isTextLayerSupported() before offering search or " +
+                "selection UI. See https://github.com/endigo/flutter_pdfview/issues/137",
+            null,
+        )
     }
 
     fun getPageCount(result: Result) {
@@ -982,6 +1023,13 @@ class FlutterPDFView(
                 "maxZoom" -> view.maxZoom = getFloat(settings, key, DEFAULT_MAX_ZOOM)
                 "minZoom" -> view.minZoom = getFloat(settings, key, DEFAULT_MIN_ZOOM)
                 "password" -> applyPassword(settings[key] as? String, null)
+                // disableLongpress() is Configurator-only, so this takes effect
+                // on the next document load rather than immediately.
+                "enableTextSelection" ->
+                    enableTextSelection =
+                        getBoolean(settings, key, DEFAULT_ENABLE_TEXT_SELECTION)
+                // Accepted and ignored: without selection there is no copy menu.
+                "enableCopy" -> Unit
                 else -> throw IllegalArgumentException("Unknown PDFView setting: $key")
             }
         }
@@ -1131,6 +1179,18 @@ class FlutterPDFView(
 
         /** Matches Dart [PDFView.enableRenderDuringScale] default. */
         const val DEFAULT_ENABLE_RENDER_DURING_SCALE = true
+
+        /** Matches Dart [PDFView.enableTextSelection] default. */
+        const val DEFAULT_ENABLE_TEXT_SELECTION = true
+
+        /**
+         * Mirrors `kPdfTextLayerUnsupportedCode` in the platform interface. Dart
+         * turns this code into an `UnsupportedError`.
+         */
+        const val TEXT_LAYER_UNSUPPORTED_CODE = "text_layer_unsupported"
+
+        /** Reported in the unsupported-text-layer message so it stays accurate. */
+        const val ANDROID_PDF_VIEWER_VERSION = "3.2.8"
 
         /**
          * Matches Dart [PDFView.thumbnailRatio] default. AndroidPdfViewer's own

--- a/packages/flutter_pdfview/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewTextLayerTest.java
+++ b/packages/flutter_pdfview/android/src/test/java/io/endigo/plugins/pdfviewflutter/FlutterPDFViewTextLayerTest.java
@@ -1,0 +1,66 @@
+package io.endigo.plugins.pdfviewflutter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Text-layer creation params and the unsupported-platform contract (#137, #285).
+ *
+ * <p>AndroidPdfViewer ships a libpdfium that exports the {@code FPDFText_*} family, but
+ * PdfiumCore binds none of it in Java, so there is no text to search or select. The native
+ * side must therefore fail these calls loudly; returning an empty result would read to an app
+ * as "this document contains no matches".
+ */
+public class FlutterPDFViewTextLayerTest {
+
+    private static Map<String, Object> params(String key, Object value) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(key, value);
+        return params;
+    }
+
+    @Test
+    public void enableTextSelection_defaultsToTrue() {
+        assertTrue(FlutterPDFView.DEFAULT_ENABLE_TEXT_SELECTION);
+        assertTrue(
+                FlutterPDFView.getBoolean(
+                        new HashMap<>(),
+                        "enableTextSelection",
+                        FlutterPDFView.DEFAULT_ENABLE_TEXT_SELECTION));
+    }
+
+    @Test
+    public void enableTextSelection_readsBothValues() {
+        assertFalse(
+                FlutterPDFView.getBoolean(
+                        params("enableTextSelection", false),
+                        "enableTextSelection",
+                        FlutterPDFView.DEFAULT_ENABLE_TEXT_SELECTION));
+        assertTrue(
+                FlutterPDFView.getBoolean(
+                        params("enableTextSelection", true),
+                        "enableTextSelection",
+                        FlutterPDFView.DEFAULT_ENABLE_TEXT_SELECTION));
+    }
+
+    @Test
+    public void enableCopy_readsBothValues() {
+        assertFalse(FlutterPDFView.getBoolean(params("enableCopy", false), "enableCopy", true));
+        assertTrue(FlutterPDFView.getBoolean(params("enableCopy", true), "enableCopy", false));
+    }
+
+    /**
+     * Pins the wire contract with Dart. {@code MethodChannelPdfViewController} turns exactly this
+     * code into an {@code UnsupportedError}; if the two ever drift, the Dart side would surface a
+     * raw PlatformException instead and the "unsupported vs. no matches" distinction would be lost.
+     */
+    @Test
+    public void unsupportedCode_matchesThePlatformInterfaceConstant() {
+        assertEquals("text_layer_unsupported", FlutterPDFView.TEXT_LAYER_UNSUPPORTED_CODE);
+    }
+}

--- a/packages/flutter_pdfview/example/README.md
+++ b/packages/flutter_pdfview/example/README.md
@@ -1,16 +1,62 @@
-# flutter_pdfview_example
+# flutter_pdfview example
 
-Demonstrates how to use the flutter_pdfview plugin.
+Demonstrates [`flutter_pdfview`](https://pub.dev/packages/flutter_pdfview) on a real device / simulator.
 
-## Getting Started
+## Run
 
-This project is a starting point for a Flutter application.
+From the repository root (workspace):
 
-A few resources to get you started if this is your first Flutter project:
+```bash
+cd packages/flutter_pdfview/example
+flutter pub get
+flutter run
+```
 
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
+## What the app covers
 
-For help getting started with Flutter, view our 
-[online documentation](https://flutter.dev/docs), which offers tutorials, 
-samples, guidance on mobile development, and a full API reference.
+| Home button | What it exercises |
+| --- | --- |
+| Open PDF | Asset load (`demo.pdf`), navigation, `setPage(withAnimation: true)` |
+| Open Landscape PDF | Landscape page size / fit |
+| Open from URL | Network download → temp file → `PDFView` |
+| Open with iPad-safe scroll | Conservative swipe / spacing config for iPad |
+| Open password-protected PDF | `onPasswordRequired` + `unlock()` (`demo-protected.pdf`) |
+| **Search Text in PDF** | **Text layer** — find, next/prev match, selection, allow-copy chips (`demo-text.pdf`, `TextSearchScreen`) |
+| Open Corrupted PDF | `onError` path |
+
+### Text search demo
+
+`TextSearchScreen` is the reference shape for apps:
+
+1. After `onViewCreated`, call `controller.isTextLayerSupported()`.
+2. Only enable search UI when that returns `true`.
+3. Use `searchText` / `nextMatch` / `previousMatch`, and listen to
+   `onSearchResultChanged` / `onTextSelectionChanged`.
+4. Toggle `enableTextSelection` / `enableCopy` at runtime (no remount).
+
+On Android the banner explains that there is no text layer yet and methods would
+throw `UnsupportedError` if called anyway.
+
+## Integration tests
+
+Drive the real native viewers:
+
+```bash
+cd packages/flutter_pdfview/example
+
+# Password unlock (Android / iOS)
+flutter test integration_test/password_test.dart
+
+# Text layer — iOS has a layer; Android asserts unsupported honestly
+flutter test integration_test/text_layer_test.dart
+```
+
+Fixtures:
+
+- `assets/demo-protected.pdf` — built via `scripts/make_protected_pdf.py`
+- `assets/demo-text.pdf` — built via `scripts/make_text_pdf.py` (known pages/terms)
+
+## Notes
+
+- Plugin dependency is `path: ../` (workspace member).
+- Min Flutter / Dart follow the package `pubspec.yaml`.

--- a/packages/flutter_pdfview/example/assets/demo-text.pdf
+++ b/packages/flutter_pdfview/example/assets/demo-text.pdf
@@ -1,0 +1,71 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [4 0 R 6 0 R 8 0 R] /Count 3 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 5 0 R >>
+endobj
+5 0 obj
+<< /Length 58 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+28 TL
+(Alpha searchable Beta) Tj
+ET
+endstream
+endobj
+6 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 7 0 R >>
+endobj
+7 0 obj
+<< /Length 48 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+28 TL
+(Gamma Delta) Tj
+ET
+endstream
+endobj
+8 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 9 0 R >>
+endobj
+9 0 obj
+<< /Length 80 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+28 TL
+(searchable Epsilon) Tj
+T*
+(searchable again) Tj
+ET
+endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000127 00000 n 
+0000000197 00000 n 
+0000000323 00000 n 
+0000000431 00000 n 
+0000000557 00000 n 
+0000000655 00000 n 
+0000000781 00000 n 
+trailer
+<< /Size 10 /Root 1 0 R >>
+startxref
+911
+%%EOF

--- a/packages/flutter_pdfview/example/integration_test/text_layer_test.dart
+++ b/packages/flutter_pdfview/example/integration_test/text_layer_test.dart
@@ -1,0 +1,255 @@
+// End-to-end coverage for the text layer, driving the real native viewers:
+// PDFKit on iOS and AndroidPdfViewer on Android.
+//
+//   cd example && flutter test integration_test/text_layer_test.dart
+//
+// The fixture has known text on known pages; see scripts/make_text_pdf.py.
+// Every assertion here is deliberately platform-aware: iOS has a text layer,
+// Android does not, and the point of these tests is that the difference is
+// reported honestly rather than as "no matches found".
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_pdfview/flutter_pdfview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Appears once on page 0 and twice on page 2 of the fixture.
+const String searchTerm = 'searchable';
+
+/// Appears exactly once, on page 1.
+const String singleMatchTerm = 'Gamma';
+
+const int textPageCount = 3;
+
+Future<File> copyAsset(String asset, String fileName) async {
+  final Directory dir = await getApplicationDocumentsDirectory();
+  final File file = File('${dir.path}/$fileName');
+  final ByteData data = await rootBundle.load(asset);
+  await file.writeAsBytes(data.buffer.asUint8List(), flush: true);
+  return file;
+}
+
+Future<bool> waitFor(
+  WidgetTester tester,
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final DateTime deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) return true;
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  return condition();
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late File textPdf;
+
+  setUpAll(() async {
+    textPdf = await copyAsset('assets/demo-text.pdf', 'demo-text.pdf');
+  });
+
+  /// Mounts the fixture and returns its controller once the document rendered.
+  Future<PDFViewController> pumpViewer(
+    WidgetTester tester, {
+    bool enableTextSelection = true,
+    bool enableCopy = true,
+    List<int>? searchIndices,
+    List<int>? searchTotals,
+  }) async {
+    PDFViewController? controller;
+    int? rendered;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: 600,
+            child: PDFView(
+              filePath: textPdf.path,
+              enableTextSelection: enableTextSelection,
+              enableCopy: enableCopy,
+              onViewCreated: (PDFViewController c) => controller = c,
+              onRender: (int? pages) => rendered = pages,
+              onSearchResultChanged: (int index, int total) {
+                searchIndices?.add(index);
+                searchTotals?.add(total);
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final bool ready = await waitFor(tester, () => controller != null && rendered != null);
+    expect(ready, isTrue, reason: 'the document never rendered');
+    expect(rendered, textPageCount);
+    return controller!;
+  }
+
+  testWidgets('reports whether this platform has a text layer', (WidgetTester tester) async {
+    final PDFViewController controller = await pumpViewer(tester);
+    final bool supported = await controller.isTextLayerSupported();
+
+    // This is the contract the rest of the suite branches on, so pin it per
+    // platform rather than accepting whatever the native side happens to say.
+    expect(supported, Platform.isIOS);
+  });
+
+  group('search', () {
+    testWidgets('finds every match with its page index', (WidgetTester tester) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      if (!await controller.isTextLayerSupported()) return;
+
+      final List<PdfTextMatch> matches = await controller.searchText(searchTerm);
+
+      expect(matches.length, 3);
+      expect(matches.map((PdfTextMatch m) => m.pageIndex), <int>[0, 2, 2]);
+      expect(matches.map((PdfTextMatch m) => m.matchIndex), <int>[0, 1, 2]);
+    });
+
+    testWidgets('a term that is absent returns no matches', (WidgetTester tester) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      if (!await controller.isTextLayerSupported()) return;
+
+      // Empty here means "searched, found nothing" — the platform that cannot
+      // search at all throws instead, which the Android test below asserts.
+      expect(await controller.searchText('Zeta-not-present'), isEmpty);
+    });
+
+    testWidgets('search is case-insensitive by default', (WidgetTester tester) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      if (!await controller.isTextLayerSupported()) return;
+
+      expect(await controller.searchText(searchTerm.toUpperCase()), hasLength(3));
+      expect(await controller.searchText(searchTerm.toUpperCase(), caseSensitive: true), isEmpty);
+    });
+
+    testWidgets('an empty query clears the session', (WidgetTester tester) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      if (!await controller.isTextLayerSupported()) return;
+
+      await controller.searchText(searchTerm);
+      expect(await controller.searchText(''), isEmpty);
+      expect(await controller.nextMatch(), isNull, reason: 'the session should be gone');
+    });
+
+    testWidgets('navigation wraps in both directions', (WidgetTester tester) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      if (!await controller.isTextLayerSupported()) return;
+
+      await controller.searchText(searchTerm); // activates match 0
+      expect((await controller.nextMatch())?.matchIndex, 1);
+      expect((await controller.nextMatch())?.matchIndex, 2);
+      expect((await controller.nextMatch())?.matchIndex, 0, reason: 'should wrap forward');
+      expect((await controller.previousMatch())?.matchIndex, 2, reason: 'should wrap back');
+    });
+
+    testWidgets('setCurrentMatch activates a match and rejects a bad index', (
+      WidgetTester tester,
+    ) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      if (!await controller.isTextLayerSupported()) return;
+
+      await controller.searchText(searchTerm);
+      expect((await controller.setCurrentMatch(2))?.pageIndex, 2);
+      expect(await controller.setCurrentMatch(99), isNull);
+      expect(await controller.setCurrentMatch(-1), isNull);
+    });
+
+    testWidgets('navigating a single-match term stays on that match', (WidgetTester tester) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      if (!await controller.isTextLayerSupported()) return;
+
+      final List<PdfTextMatch> matches = await controller.searchText(singleMatchTerm);
+      expect(matches, hasLength(1));
+      expect(matches.single.pageIndex, 1);
+      expect((await controller.nextMatch())?.matchIndex, 0);
+    });
+
+    testWidgets('onSearchResultChanged tracks the active match', (WidgetTester tester) async {
+      final List<int> indices = <int>[];
+      final List<int> totals = <int>[];
+      final PDFViewController controller = await pumpViewer(
+        tester,
+        searchIndices: indices,
+        searchTotals: totals,
+      );
+      if (!await controller.isTextLayerSupported()) return;
+
+      await controller.searchText(searchTerm);
+      await waitFor(tester, () => indices.isNotEmpty);
+      expect(indices.last, 0);
+      expect(totals.last, 3);
+
+      await controller.nextMatch();
+      await waitFor(tester, () => indices.last == 1);
+      expect(indices.last, 1);
+
+      await controller.clearSearch();
+      await waitFor(tester, () => indices.last == -1);
+      expect(indices.last, -1);
+      expect(totals.last, 0);
+    });
+  });
+
+  group('selection', () {
+    testWidgets('nothing is selected on a freshly opened document', (WidgetTester tester) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      if (!await controller.isTextLayerSupported()) return;
+
+      expect(await controller.getSelectedText(), isNull);
+    });
+
+    testWidgets('clearSelection is safe with no selection', (WidgetTester tester) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      await expectLater(controller.clearSelection(), completes);
+    });
+
+    testWidgets('a viewer built with selection disabled still renders and searches', (
+      WidgetTester tester,
+    ) async {
+      // #108: disabling selection must not cost the document its text layer.
+      final PDFViewController controller = await pumpViewer(
+        tester,
+        enableTextSelection: false,
+        enableCopy: false,
+      );
+      if (!await controller.isTextLayerSupported()) return;
+
+      expect(await controller.searchText(searchTerm), hasLength(3));
+      expect(await controller.getSelectedText(), isNull);
+    });
+  });
+
+  group('platform without a text layer', () {
+    testWidgets('text queries throw instead of reporting nothing found', (
+      WidgetTester tester,
+    ) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      if (await controller.isTextLayerSupported()) return;
+
+      // The regression this guards: returning [] / null here would read as
+      // "this document has no matches" and silently ship broken search.
+      await expectLater(controller.searchText(searchTerm), throwsUnsupportedError);
+      await expectLater(controller.getSelectedText(), throwsUnsupportedError);
+      await expectLater(controller.nextMatch(), throwsUnsupportedError);
+      await expectLater(controller.previousMatch(), throwsUnsupportedError);
+      await expectLater(controller.setCurrentMatch(0), throwsUnsupportedError);
+    });
+
+    testWidgets('clearing stays a no-op', (WidgetTester tester) async {
+      final PDFViewController controller = await pumpViewer(tester);
+      if (await controller.isTextLayerSupported()) return;
+
+      await expectLater(controller.clearSearch(), completes);
+      await expectLater(controller.clearSelection(), completes);
+    });
+  });
+}

--- a/packages/flutter_pdfview/example/lib/main.dart
+++ b/packages/flutter_pdfview/example/lib/main.dart
@@ -1,3 +1,16 @@
+/// Example app for [flutter_pdfview](https://pub.dev/packages/flutter_pdfview).
+///
+/// Home screen demos (see also `example/README.md`):
+/// - Open PDF / landscape / remote / iPad-safe scroll
+/// - Password-protected unlock (`demo-protected.pdf`)
+/// - **Text search** (`TextSearchScreen` + `demo-text.pdf`) — iOS has a text
+///   layer; Android shows an unsupported banner
+/// - Corrupted PDF error path
+///
+/// Integration tests: `integration_test/password_test.dart`,
+/// `integration_test/text_layer_test.dart`.
+library;
+
 import 'dart:async';
 import 'dart:io';
 
@@ -160,7 +173,7 @@ class _MyAppState extends State<MyApp> {
       themeMode: _themeMode,
       home: Scaffold(
         appBar: AppBar(
-          title: const Text('Plugin example app'),
+          title: const Text('flutter_pdfview example'),
           actions: <Widget>[
             IconButton(
               tooltip: 'Theme: ${_themeMode.name}',
@@ -172,8 +185,17 @@ class _MyAppState extends State<MyApp> {
         body: Center(
           child: Builder(
             builder: (BuildContext context) {
-              return Column(
+              return ListView(
+                padding: const EdgeInsets.symmetric(vertical: 16),
                 children: <Widget>[
+                  const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+                    child: Text(
+                      'Demos for layout, password unlock, and the iOS text layer '
+                      '(search / selection / copy). See example/README.md.',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
                   TextButton(
                     child: const Text('Open PDF'),
                     onPressed: () {
@@ -236,7 +258,7 @@ class _MyAppState extends State<MyApp> {
                     },
                   ),
                   TextButton(
-                    child: const Text('Search Text in PDF'),
+                    child: const Text('Search Text in PDF (text layer)'),
                     onPressed: () {
                       if (textPathPDF.isNotEmpty) {
                         Navigator.push(

--- a/packages/flutter_pdfview/example/lib/main.dart
+++ b/packages/flutter_pdfview/example/lib/main.dart
@@ -32,6 +32,7 @@ class _MyAppState extends State<MyApp> {
   String remotePDFpath = '';
   String corruptedPathPDF = '';
   String protectedPathPDF = '';
+  String textPathPDF = '';
   ThemeMode _themeMode = ThemeMode.system;
 
   @override
@@ -58,6 +59,11 @@ class _MyAppState extends State<MyApp> {
     fromAsset('assets/demo-protected.pdf', 'protected.pdf').then((f) {
       setState(() {
         protectedPathPDF = f.path;
+      });
+    });
+    fromAsset('assets/demo-text.pdf', 'text.pdf').then((f) {
+      setState(() {
+        textPathPDF = f.path;
       });
     });
 
@@ -230,6 +236,19 @@ class _MyAppState extends State<MyApp> {
                     },
                   ),
                   TextButton(
+                    child: const Text('Search Text in PDF'),
+                    onPressed: () {
+                      if (textPathPDF.isNotEmpty) {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => TextSearchScreen(path: textPathPDF),
+                          ),
+                        );
+                      }
+                    },
+                  ),
+                  TextButton(
                     child: const Text('Open Corrupted PDF'),
                     onPressed: () {
                       if (pathPDF.isNotEmpty) {
@@ -247,6 +266,171 @@ class _MyAppState extends State<MyApp> {
             },
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Find-in-document demo (#137), plus the copy/selection switches from #108.
+///
+/// Shows the shape apps are expected to use: ask
+/// [PDFViewController.isTextLayerSupported] first and only offer search where it
+/// exists, because the text methods throw [UnsupportedError] elsewhere rather
+/// than pretending the document has no matches.
+class TextSearchScreen extends StatefulWidget {
+  /// Path of the document to display.
+  const TextSearchScreen({super.key, required this.path});
+
+  /// Path of the document to display.
+  final String path;
+
+  @override
+  State<TextSearchScreen> createState() => _TextSearchScreenState();
+}
+
+class _TextSearchScreenState extends State<TextSearchScreen> {
+  final TextEditingController _query = TextEditingController(text: 'searchable');
+  PDFViewController? _controller;
+  bool? _textLayerSupported;
+  int _current = -1;
+  int _total = 0;
+  String? _selection;
+  bool _allowSelection = true;
+  bool _allowCopy = true;
+  String? _error;
+
+  @override
+  void dispose() {
+    _query.dispose();
+    super.dispose();
+  }
+
+  Future<void> _runSearch() async {
+    final PDFViewController? controller = _controller;
+    if (controller == null) return;
+    setState(() => _error = null);
+    try {
+      final List<PdfTextMatch> matches = await controller.searchText(_query.text);
+      if (!mounted) return;
+      setState(() {
+        _total = matches.length;
+        _current = matches.isEmpty ? -1 : 0;
+      });
+    } on UnsupportedError catch (e) {
+      // Reached only if the UI ignored isTextLayerSupported.
+      if (mounted) setState(() => _error = e.message?.toString());
+    }
+  }
+
+  Future<void> _step({required bool forward}) async {
+    final PDFViewController? controller = _controller;
+    if (controller == null || _total == 0) return;
+    final PdfTextMatch? match = forward
+        ? await controller.nextMatch()
+        : await controller.previousMatch();
+    if (mounted && match != null) setState(() => _current = match.matchIndex);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool supported = _textLayerSupported ?? false;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Text search')),
+      body: Column(
+        children: <Widget>[
+          if (_textLayerSupported == false)
+            const Padding(
+              padding: EdgeInsets.all(12),
+              child: Text(
+                'This platform has no text layer, so search and selection are '
+                'unavailable. On Android, AndroidPdfViewer does not bind '
+                "Pdfium's text API — see issue #137.",
+              ),
+            ),
+          if (_error != null)
+            Padding(padding: const EdgeInsets.all(12), child: Text('Error: $_error')),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: TextField(
+                    controller: _query,
+                    enabled: supported,
+                    decoration: const InputDecoration(labelText: 'Find in document'),
+                    onSubmitted: (_) => _runSearch(),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: supported ? _runSearch : null,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.keyboard_arrow_up),
+                  onPressed: supported && _total > 0 ? () => _step(forward: false) : null,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.keyboard_arrow_down),
+                  onPressed: supported && _total > 0 ? () => _step(forward: true) : null,
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              children: <Widget>[
+                Text(_total == 0 ? 'No matches' : 'Match ${_current + 1} of $_total'),
+                const Spacer(),
+                if (_selection != null)
+                  Flexible(child: Text('Selected: $_selection', overflow: TextOverflow.ellipsis)),
+              ],
+            ),
+          ),
+          Wrap(
+            children: <Widget>[
+              // Together these two are the #108 "stop text leaving the document"
+              // configuration. Both push at runtime, without a remount.
+              FilterChip(
+                label: const Text('Allow selection'),
+                selected: _allowSelection,
+                onSelected: (bool v) => setState(() => _allowSelection = v),
+              ),
+              const SizedBox(width: 8),
+              FilterChip(
+                label: const Text('Allow copy'),
+                selected: _allowCopy,
+                onSelected: (bool v) => setState(() => _allowCopy = v),
+              ),
+            ],
+          ),
+          Expanded(
+            child: PDFView(
+              filePath: widget.path,
+              enableTextSelection: _allowSelection,
+              enableCopy: _allowCopy,
+              onViewCreated: (PDFViewController controller) async {
+                final bool supported = await controller.isTextLayerSupported();
+                if (!mounted) return;
+                setState(() {
+                  _controller = controller;
+                  _textLayerSupported = supported;
+                });
+              },
+              onTextSelectionChanged: (String? text) {
+                if (mounted) setState(() => _selection = text);
+              },
+              onSearchResultChanged: (int index, int total) {
+                if (mounted) {
+                  setState(() {
+                    _current = index;
+                    _total = total;
+                  });
+                }
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/packages/flutter_pdfview/example/pubspec.yaml
+++ b/packages/flutter_pdfview/example/pubspec.yaml
@@ -53,6 +53,7 @@ flutter:
     - assets/demo-link.pdf
     - assets/demo-landscape.pdf
     - assets/demo-protected.pdf
+    - assets/demo-text.pdf
   #  - images/a_dot_burr.jpeg
   #  - images/a_dot_ham.jpeg
   # An image asset can refer to one or more resolution-specific "variants", see

--- a/packages/flutter_pdfview/example/test/widget_test.dart
+++ b/packages/flutter_pdfview/example/test/widget_test.dart
@@ -14,11 +14,13 @@ void main() {
       await tester.pumpWidget(const MyApp(loadDocuments: false));
       await tester.pump();
 
-      expect(find.text('Plugin example app'), findsOneWidget);
+      expect(find.text('flutter_pdfview example'), findsOneWidget);
       expect(find.text('Open PDF'), findsOneWidget);
       expect(find.text('Open Landscape PDF'), findsOneWidget);
       expect(find.text('Remote PDF'), findsOneWidget);
       expect(find.text('Open PDF (iPad Safe Mode)'), findsOneWidget);
+      expect(find.text('Open Password Protected PDF'), findsOneWidget);
+      expect(find.text('Search Text in PDF (text layer)'), findsOneWidget);
       expect(find.text('Open Corrupted PDF'), findsOneWidget);
       // Theme toggle lives in the home AppBar.
       expect(find.byTooltip('Theme: system'), findsOneWidget);
@@ -52,7 +54,23 @@ void main() {
       await tester.tap(openPdf);
       await tester.pump();
       expect(find.text('Document'), findsNothing);
-      expect(find.text('Plugin example app'), findsOneWidget);
+      expect(find.text('flutter_pdfview example'), findsOneWidget);
+    });
+  });
+
+  group('TextSearchScreen', () {
+    testWidgets('shows search chrome and unsupported banner until layer is known', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const MaterialApp(home: TextSearchScreen(path: 'demo-text.pdf')));
+      await tester.pump();
+
+      expect(find.text('Text search'), findsOneWidget);
+      expect(find.text('Find in document'), findsOneWidget);
+      expect(find.text('Allow selection'), findsOneWidget);
+      expect(find.text('Allow copy'), findsOneWidget);
+      // No controller yet → treat as unsupported UI (buttons disabled via supported flag).
+      expect(find.byIcon(Icons.search), findsOneWidget);
     });
   });
 

--- a/packages/flutter_pdfview/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
+++ b/packages/flutter_pdfview/ios/flutter_pdfview/Sources/flutter_pdfview/FlutterPDFView.swift
@@ -172,6 +172,22 @@ final class PDFViewController: NSObject, FlutterPlatformView, PDFViewDelegate {
             pdfView.unlock(call, result: result)
         case "getScreenshot":
             pdfView.getScreenshot(call, result: result)
+        case "isTextLayerSupported":
+            result(true)
+        case "searchText":
+            pdfView.searchText(call, result: result)
+        case "nextMatch":
+            pdfView.nextMatch(call, result: result)
+        case "previousMatch":
+            pdfView.previousMatch(call, result: result)
+        case "setCurrentMatch":
+            pdfView.setCurrentMatch(call, result: result)
+        case "clearSearch":
+            pdfView.clearSearch(call, result: result)
+        case "getSelectedText":
+            pdfView.getSelectedText(call, result: result)
+        case "clearSelection":
+            pdfView.clearSelection(call, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -189,6 +205,34 @@ final class PDFViewController: NSObject, FlutterPlatformView, PDFViewDelegate {
         // Unregister from the messenger; otherwise the engine keeps one dead
         // handler per created platform view for the app's lifetime (#261).
         channel.setMethodCallHandler(nil)
+    }
+}
+
+// MARK: - PDFKit view with copy / selection control
+
+/// PDFKit's `PDFView` always offers the system edit menu for selected text.
+/// Subclassing lets #108 refuse the copy-ish actions without tearing down the
+/// text layer, so selection can stay usable while copying is blocked.
+final class FPVPDFView: PDFView {
+    /// When false, copy / cut / share / look-up actions are refused (#108).
+    var enableCopy = true
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        guard !enableCopy else {
+            return super.canPerformAction(action, withSender: sender)
+        }
+        // `copy:` and `cut:` are public selectors. The share / define / look-up
+        // entries are private and have been renamed across iOS releases, so they
+        // are matched by substring — a miss only means an extra menu entry, never
+        // a crash.
+        if action == #selector(copy(_:)) || action == #selector(cut(_:)) {
+            return false
+        }
+        let name = action.description.lowercased()
+        for blocked in ["share", "define", "lookup", "translate"] where name.contains(blocked) {
+            return false
+        }
+        return super.canPerformAction(action, withSender: sender)
     }
 }
 
@@ -213,7 +257,7 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate, PDFDoc
 
     private weak var controller: PDFViewController?
 
-    private let pdfView: PDFView
+    private let pdfView: FPVPDFView
     private var document: PDFDocument?
     private var scrollView: UIScrollView?
     private var pageCount: NSNumber?
@@ -268,6 +312,18 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate, PDFDoc
     /// re-render. `nil` until Dart updates it.
     private var swipeEnabledOverride: Bool?
 
+    /// Whether the user may long-press to select text (#285).
+    private var enableTextSelection = true
+    /// Whether the system edit menu offers copy / share for a selection (#108).
+    private var enableCopy = true
+
+    /// Results of the active `findString` session (#137), in document order.
+    private var searchSelections: [PDFSelection] = []
+    /// Index into [searchSelections] of the active match, or -1 when none.
+    private var currentSearchIndex = -1
+    /// Last text reported through `onTextSelectionChanged`, to suppress repeats.
+    private var lastReportedSelectionText: String?
+
     init(frame: CGRect, arguments args: Any?, controller: PDFViewController) {
         self.controller = controller
 
@@ -278,7 +334,7 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate, PDFDoc
         if pdfFrame.isEmpty || pdfFrame.size.width <= 0 || pdfFrame.size.height <= 0 {
             pdfFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
         }
-        pdfView = PDFView(frame: pdfFrame)
+        pdfView = FPVPDFView(frame: pdfFrame)
 
         super.init(frame: frame)
 
@@ -295,6 +351,15 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate, PDFDoc
         // PDFKit is vector, but ensure the host layer is not stuck at 1× when the
         // Flutter platform view attaches before a window is available (#158).
         applyDisplayScale()
+
+        // Removed by the existing deinit, which already calls
+        // NotificationCenter.default.removeObserver(self).
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleSelectionChanged(_:)),
+            name: .PDFViewSelectionChanged,
+            object: pdfView
+        )
 
         pendingLoadArguments = args as? [String: Any]
         // If Flutter already handed us a non-zero frame, open immediately;
@@ -385,6 +450,10 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate, PDFDoc
         let pageFling = args?.bool("pageFling") ?? false
         let enableSwipe = args?.bool("enableSwipe") ?? false
         preventLinkNavigation = args?.bool("preventLinkNavigation") ?? false
+        // Default to true when the key is absent, matching Dart.
+        enableTextSelection = args?.number("enableTextSelection")?.boolValue ?? true
+        enableCopy = args?.number("enableCopy")?.boolValue ?? true
+        applyTextInteractionSettings()
         setColorMode(Self.colorMode(fromSettings: args) ?? .light)
 
         defaultPageIndex = args?.integer("defaultPage") ?? 0
@@ -563,6 +632,14 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate, PDFDoc
         }
 
         defaultPage = document.page(at: defaultPageIndex)
+
+        // PDFKit installs its long-press recognizers as the document attaches, so
+        // re-apply the selection / copy policy afterwards (#108, #285). A second
+        // pass after the run loop catches nested page views.
+        applyTextInteractionSettings()
+        DispatchQueue.main.async { [weak self] in
+            self?.applyTextInteractionSettings()
+        }
 
         // Configure scroll view with defensive handling for iPad.
         // PDFKit may not expose its scroll view immediately; retry a few
@@ -1314,9 +1391,203 @@ final class FlutterPDFView: UIView, FlutterPlatformView, PDFViewDelegate, PDFDoc
             setNeedsLayout()
         }
 
+        var textInteractionChanged = false
+        if settings.keys.contains("enableTextSelection") {
+            enableTextSelection = settings.bool("enableTextSelection")
+            textInteractionChanged = true
+        }
+        if settings.keys.contains("enableCopy") {
+            enableCopy = settings.bool("enableCopy")
+            textInteractionChanged = true
+        }
+        if textInteractionChanged {
+            applyTextInteractionSettings()
+        }
+
         if needsRerender {
             rerenderPreservingPosition()
         }
+        result(nil)
+    }
+
+    // MARK: - Text layer (#285 selection, #137 search, #108 copy)
+
+    /// Pushes the selection / copy policy onto the PDFKit view.
+    private func applyTextInteractionSettings() {
+        // Copy needs something selected, so disabling selection disables copy too.
+        pdfView.enableCopy = enableCopy && enableTextSelection
+        setLongPressGesturesEnabled(enableTextSelection)
+        if !enableTextSelection {
+            clearActiveSelection(notify: true)
+        }
+    }
+
+    /// Enables or disables the long-press recognizers that start text selection.
+    ///
+    /// PDFKit spreads them across nested page views, so the whole subtree is
+    /// walked rather than just `pdfView` itself.
+    private func setLongPressGesturesEnabled(_ enabled: Bool) {
+        func apply(to view: UIView) {
+            for recognizer in view.gestureRecognizers ?? []
+                where recognizer is UILongPressGestureRecognizer
+            {
+                recognizer.isEnabled = enabled
+            }
+            for subview in view.subviews {
+                apply(to: subview)
+            }
+        }
+        apply(to: pdfView)
+    }
+
+    @objc private func handleSelectionChanged(_: Notification) {
+        guard enableTextSelection else {
+            // Clear anything that slipped through after selection was disabled.
+            if pdfView.currentSelection != nil {
+                pdfView.clearSelection()
+            }
+            return
+        }
+        let text = pdfView.currentSelection?.string
+        guard text != lastReportedSelectionText else { return }
+        lastReportedSelectionText = text
+        reportSelectionChanged(text)
+    }
+
+    /// Sends `onTextSelectionChanged`, encoding "no selection" as `NSNull`.
+    private func reportSelectionChanged(_ text: String?) {
+        var arguments: [String: Any] = [:]
+        arguments["text"] = text ?? NSNull()
+        controller?.invokeChannelMethod("onTextSelectionChanged", arguments: arguments)
+    }
+
+    private func clearActiveSelection(notify: Bool) {
+        pdfView.clearSelection()
+        let hadSelection = lastReportedSelectionText != nil
+        lastReportedSelectionText = nil
+        if notify, hadSelection {
+            reportSelectionChanged(nil)
+        }
+    }
+
+    /// Describes the match at [index] for Dart, or nil when out of range.
+    private func matchMap(at index: Int) -> [String: Any]? {
+        guard index >= 0, index < searchSelections.count else { return nil }
+        let selection = searchSelections[index]
+        var pageIndex = 0
+        if let page = selection.pages.first, let document {
+            // `index(for:)` is non-optional and reports NSNotFound on a miss.
+            let found = document.index(for: page)
+            if found != NSNotFound {
+                pageIndex = found
+            }
+        }
+        var map: [String: Any] = ["pageIndex": pageIndex, "matchIndex": index]
+        map["text"] = selection.string ?? NSNull()
+        return map
+    }
+
+    @discardableResult
+    private func activateSearchMatch(at index: Int, animate: Bool) -> [String: Any]? {
+        guard index >= 0, index < searchSelections.count else { return nil }
+        currentSearchIndex = index
+        let selection = searchSelections[index]
+        // Highlight every match; currentSelection marks the active one.
+        pdfView.highlightedSelections = searchSelections
+        pdfView.setCurrentSelection(selection, animate: animate)
+        pdfView.go(to: selection)
+        let map = matchMap(at: index)
+        reportSearchResultChanged(currentIndex: index, total: searchSelections.count)
+        return map
+    }
+
+    private func reportSearchResultChanged(currentIndex: Int, total: Int) {
+        controller?.invokeChannelMethod(
+            "onSearchResultChanged",
+            arguments: ["currentIndex": currentIndex, "total": total]
+        )
+    }
+
+    private func clearSearchState(notify: Bool) {
+        searchSelections = []
+        currentSearchIndex = -1
+        pdfView.highlightedSelections = nil
+        // Deliberately leaves any user text selection alone.
+        if notify {
+            reportSearchResultChanged(currentIndex: -1, total: 0)
+        }
+    }
+
+    func searchText(_ call: FlutterMethodCall, result: FlutterResult) {
+        let arguments = call.arguments as? [String: Any]
+        let query = arguments?["query"] as? String ?? ""
+        let caseSensitive = arguments?.number("caseSensitive")?.boolValue ?? false
+
+        guard !query.isEmpty, let document, !document.isLocked else {
+            clearSearchState(notify: true)
+            result([])
+            return
+        }
+
+        var options: NSString.CompareOptions = []
+        if !caseSensitive {
+            options.insert(.caseInsensitive)
+        }
+        searchSelections = document.findString(query, withOptions: options)
+
+        guard !searchSelections.isEmpty else {
+            currentSearchIndex = -1
+            pdfView.highlightedSelections = nil
+            reportSearchResultChanged(currentIndex: -1, total: 0)
+            result([])
+            return
+        }
+
+        // Activate the first hit so the user sees a result immediately.
+        activateSearchMatch(at: 0, animate: true)
+        result((0 ..< searchSelections.count).compactMap { matchMap(at: $0) })
+    }
+
+    func nextMatch(_: FlutterMethodCall, result: FlutterResult) {
+        guard !searchSelections.isEmpty else {
+            result(nil)
+            return
+        }
+        let next = (currentSearchIndex + 1) % searchSelections.count
+        result(activateSearchMatch(at: next, animate: true))
+    }
+
+    func previousMatch(_: FlutterMethodCall, result: FlutterResult) {
+        guard !searchSelections.isEmpty else {
+            result(nil)
+            return
+        }
+        let previous = currentSearchIndex <= 0
+            ? searchSelections.count - 1
+            : currentSearchIndex - 1
+        result(activateSearchMatch(at: previous, animate: true))
+    }
+
+    func setCurrentMatch(_ call: FlutterMethodCall, result: FlutterResult) {
+        let index = (call.arguments as? [String: Any])?.integer("index") ?? -1
+        result(activateSearchMatch(at: index, animate: true))
+    }
+
+    func clearSearch(_: FlutterMethodCall, result: FlutterResult) {
+        clearSearchState(notify: true)
+        result(nil)
+    }
+
+    func getSelectedText(_: FlutterMethodCall, result: FlutterResult) {
+        guard enableTextSelection else {
+            result(nil)
+            return
+        }
+        result(pdfView.currentSelection?.string)
+    }
+
+    func clearSelection(_: FlutterMethodCall, result: FlutterResult) {
+        clearActiveSelection(notify: true)
         result(nil)
     }
 

--- a/packages/flutter_pdfview/lib/flutter_pdfview.dart
+++ b/packages/flutter_pdfview/lib/flutter_pdfview.dart
@@ -50,8 +50,11 @@ export 'package:flutter_pdfview_platform_interface/flutter_pdfview_platform_inte
         PageErrorCallback,
         PasswordRequiredCallback,
         PdfColorMode,
+        PdfTextMatch,
         RenderCallback,
-        TapCallback;
+        SearchResultChangedCallback,
+        TapCallback,
+        TextSelectionChangedCallback;
 
 part 'src/pdf_view.dart';
 part 'src/pdf_view_controller.dart';

--- a/packages/flutter_pdfview/lib/flutter_pdfview.dart
+++ b/packages/flutter_pdfview/lib/flutter_pdfview.dart
@@ -14,6 +14,10 @@
 ///   onViewCreated: (PDFViewController controller) async {
 ///     final int? pages = await controller.getPageCount();
 ///     await controller.setPage(0);
+///     // Text search is iOS-only today — always check first.
+///     if (await controller.isTextLayerSupported()) {
+///       await controller.searchText('invoice');
+///     }
 ///   },
 /// )
 /// ```

--- a/packages/flutter_pdfview/lib/src/pdf_view.dart
+++ b/packages/flutter_pdfview/lib/src/pdf_view.dart
@@ -26,6 +26,8 @@ class PDFView extends StatefulWidget {
     this.onLoadComplete,
     this.onDraw,
     this.onTap,
+    this.onTextSelectionChanged,
+    this.onSearchResultChanged,
     this.gestureRecognizers,
     this.enableSwipe = true,
     this.swipeHorizontal = false,
@@ -53,6 +55,8 @@ class PDFView extends StatefulWidget {
     this.backgroundColor,
     this.maxZoom = 4.0,
     this.minZoom = 1.0,
+    this.enableTextSelection = true,
+    this.enableCopy = true,
   }) : assert(filePath != null || pdfData != null),
        assert(maxZoom > 0, 'maxZoom must be greater than 0'),
        assert(minZoom > 0, 'minZoom must be greater than 0'),
@@ -104,6 +108,20 @@ class PDFView extends StatefulWidget {
   /// Double-tap zoom and link handling still work; the native side reports the
   /// single tap without consuming the event for those features.
   final TapCallback? onTap;
+
+  /// Invoked when the user changes the text selection, with the selected string
+  /// or `null` when the selection is cleared.
+  ///
+  /// Only delivered while [enableTextSelection] is `true`, and only on platforms
+  /// with a text layer — see [PDFViewController.isTextLayerSupported].
+  final TextSelectionChangedCallback? onTextSelectionChanged;
+
+  /// Invoked when the active search match changes, after
+  /// [PDFViewController.searchText], [PDFViewController.nextMatch],
+  /// [PDFViewController.previousMatch] or [PDFViewController.setCurrentMatch].
+  ///
+  /// The index is `-1` and the total `0` when the search is cleared.
+  final SearchResultChangedCallback? onSearchResultChanged;
 
   /// Which gestures should be consumed by the pdf view.
   ///
@@ -267,6 +285,28 @@ class PDFView extends StatefulWidget {
 
   /// Minimum zoom level. Defaults to 1.0 (fit to page).
   final double minZoom;
+
+  /// Whether the user may long-press to select text in the document.
+  ///
+  /// Defaults to `true`.
+  ///
+  /// - **iOS**: maps to PDFKit's built-in selection
+  ///   ([#285](https://github.com/endigo/flutter_pdfview/issues/285)). Setting it
+  ///   to `false` disables the long-press recognizers and clears any selection,
+  ///   which is the supported way to stop users copying text out of a document
+  ///   ([#108](https://github.com/endigo/flutter_pdfview/issues/108)).
+  /// - **Android**: AndroidPdfViewer has no selection UI, so `false` only
+  ///   suppresses the long-press callback. There is nothing to select either
+  ///   way. Applied on the next document load rather than immediately.
+  final bool enableTextSelection;
+
+  /// Whether the system edit menu offers copy / share / look-up for a selection.
+  ///
+  /// Defaults to `true`. Set both this and [enableTextSelection] to `false` to
+  /// stop text leaving the document entirely.
+  ///
+  /// **iOS only** — Android has no selection menu to suppress.
+  final bool enableCopy;
 
   @override
   State<PDFView> createState() => _PDFViewState();

--- a/packages/flutter_pdfview/lib/src/pdf_view_controller.dart
+++ b/packages/flutter_pdfview/lib/src/pdf_view_controller.dart
@@ -107,6 +107,64 @@ class PDFViewController {
   Future<bool?> setPage(int page, {bool withAnimation = false}) =>
       _platform.setPage(page, withAnimation: withAnimation);
 
+  /// Whether this platform has a text layer at all.
+  ///
+  /// `true` on iOS. `false` on Android: AndroidPdfViewer does not bind Pdfium's
+  /// `FPDFText_*` API, so there is nothing to select or search
+  /// ([#137](https://github.com/endigo/flutter_pdfview/issues/137),
+  /// [#285](https://github.com/endigo/flutter_pdfview/issues/285)).
+  ///
+  /// Branch on this before offering search or selection UI — the text methods
+  /// below throw [UnsupportedError] rather than quietly reporting no results.
+  Future<bool> isTextLayerSupported() => _platform.isTextLayerSupported();
+
+  /// Searches the document for [query] and returns every match, in document
+  /// order.
+  ///
+  /// The first match becomes active: it is highlighted and scrolled into view,
+  /// and [PDFView.onSearchResultChanged] fires. Each call replaces the previous
+  /// search session; an empty [query] clears it and returns an empty list.
+  ///
+  /// An empty result means the document genuinely contains no match. Throws
+  /// [UnsupportedError] where there is no text layer — see
+  /// [isTextLayerSupported].
+  Future<List<PdfTextMatch>> searchText(String query, {bool caseSensitive = false}) =>
+      _platform.searchText(query, caseSensitive: caseSensitive);
+
+  /// Activates the next match, wrapping to the first at the end.
+  ///
+  /// Returns the newly active match, or `null` when no search is active.
+  /// Throws [UnsupportedError] where there is no text layer.
+  Future<PdfTextMatch?> nextMatch() => _platform.nextMatch();
+
+  /// Activates the previous match, wrapping to the last at the start.
+  ///
+  /// Returns the newly active match, or `null` when no search is active.
+  /// Throws [UnsupportedError] where there is no text layer.
+  Future<PdfTextMatch?> previousMatch() => _platform.previousMatch();
+
+  /// Activates the match at [index] of the last [searchText] result.
+  ///
+  /// Returns the match, or `null` when [index] is out of range.
+  /// Throws [UnsupportedError] where there is no text layer.
+  Future<PdfTextMatch?> setCurrentMatch(int index) => _platform.setCurrentMatch(index);
+
+  /// Clears search highlights and forgets the last [searchText] result.
+  ///
+  /// A no-op — never an error — where there is no text layer.
+  Future<void> clearSearch() => _platform.clearSearch();
+
+  /// Returns the selected text, or `null` when nothing is selected.
+  ///
+  /// Throws [UnsupportedError] where there is no text layer, so that `null`
+  /// keeps meaning "nothing is selected".
+  Future<String?> getSelectedText() => _platform.getSelectedText();
+
+  /// Clears the current text selection, if any.
+  ///
+  /// A no-op — never an error — where there is no text layer.
+  Future<void> clearSelection() => _platform.clearSelection();
+
   Future<void> _updateWidget(PDFView widget, {required PdfColorMode resolvedColorMode}) async {
     // Refresh callbacks even when no setting changed, so the native view never
     // dispatches into closures from a previous build.

--- a/packages/flutter_pdfview/lib/src/pdf_view_settings.dart
+++ b/packages/flutter_pdfview/lib/src/pdf_view_settings.dart
@@ -33,6 +33,8 @@ PdfViewSettings _settingsFromWidget(PDFView widget, {required PdfColorMode resol
     backgroundColor: widget.backgroundColor,
     maxZoom: widget.maxZoom,
     minZoom: widget.minZoom,
+    enableTextSelection: widget.enableTextSelection,
+    enableCopy: widget.enableCopy,
   );
 }
 
@@ -51,5 +53,7 @@ PdfViewCallbacks _callbacksFromWidget(PDFView widget) {
     onLoadComplete: widget.onLoadComplete,
     onDraw: widget.onDraw,
     onTap: widget.onTap,
+    onTextSelectionChanged: widget.onTextSelectionChanged,
+    onSearchResultChanged: widget.onSearchResultChanged,
   );
 }

--- a/packages/flutter_pdfview/pubspec.yaml
+++ b/packages/flutter_pdfview/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_pdfview
 description: A Flutter plugin that provides a PDFView widget on Android and iOS.
-version: 1.5.0-beta.12
+version: 1.5.0-beta.13
 homepage: https://github.com/endigo/flutter_pdfview
 repository: https://github.com/endigo/flutter_pdfview
 issue_tracker: https://github.com/endigo/flutter_pdfview/issues
@@ -26,7 +26,7 @@ dependencies:
   # The shared platform interface. Inside this workspace the constraint resolves
   # to packages/flutter_pdfview_platform_interface; on pub.dev it resolves to the
   # published package, so that one must be released first.
-  flutter_pdfview_platform_interface: ^1.0.1
+  flutter_pdfview_platform_interface: ^1.1.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/packages/flutter_pdfview/test/creation_params_test.dart
+++ b/packages/flutter_pdfview/test/creation_params_test.dart
@@ -29,6 +29,8 @@ const Set<String> _expectedKeys = <String>{
   'backgroundColor',
   'maxZoom',
   'minZoom',
+  'enableTextSelection',
+  'enableCopy',
 };
 
 /// Runs a body on iOS, where `PDFView` uses the simplest platform view path.
@@ -147,6 +149,8 @@ void main() {
       expect(params['preventLinkNavigation'], isFalse);
       expect(params['maxZoom'], 4.0);
       expect(params['minZoom'], 1.0);
+      expect(params['enableTextSelection'], isTrue);
+      expect(params['enableCopy'], isTrue);
     }, variant: _iOS);
 
     testWidgets('serializes a fully customised widget', (WidgetTester tester) async {
@@ -550,10 +554,7 @@ void main() {
       viewCalls.clear();
       await controller!.setPage(2);
       expect(viewCalls.single.method, 'setPage');
-      expect(viewCalls.single.arguments, <String, Object?>{
-        'page': 2,
-        'withAnimation': false,
-      });
+      expect(viewCalls.single.arguments, <String, Object?>{'page': 2, 'withAnimation': false});
     }, variant: _iOS);
   });
 }

--- a/packages/flutter_pdfview_platform_interface/CHANGELOG.md
+++ b/packages/flutter_pdfview_platform_interface/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.1.0
+
+- Add the text layer to the interface: `PdfTextMatch`, the
+  `TextSelectionChangedCallback` / `SearchResultChangedCallback` signatures, the
+  `enableTextSelection` / `enableCopy` settings, and the search and selection
+  methods on `PdfViewPlatformController`
+- Add `PdfViewPlatformController.isTextLayerSupported`, and
+  `kPdfTextLayerUnsupportedCode` — the `PlatformException.code` an implementation
+  must use when it has no text layer. `MethodChannelPdfViewController` turns it
+  into an `UnsupportedError`, so an empty search result always means "searched,
+  found nothing" and never "not supported here"
+- Non-breaking for existing implementations that extend `FlutterPdfViewPlatform`
+
 ## 1.0.1
 
 - `PdfViewPlatformController.setPage` accepts optional `withAnimation` (default `false`; Android

--- a/packages/flutter_pdfview_platform_interface/CHANGELOG.md
+++ b/packages/flutter_pdfview_platform_interface/CHANGELOG.md
@@ -9,6 +9,8 @@
   must use when it has no text layer. `MethodChannelPdfViewController` turns it
   into an `UnsupportedError`, so an empty search result always means "searched,
   found nothing" and never "not supported here"
+- Document the text-layer contract in the package README (unsupported must throw,
+  not return empty)
 - Non-breaking for existing implementations that extend `FlutterPdfViewPlatform`
 
 ## 1.0.1

--- a/packages/flutter_pdfview_platform_interface/README.md
+++ b/packages/flutter_pdfview_platform_interface/README.md
@@ -11,12 +11,34 @@ This package declares the interface that platform-specific implementations of
 | Type | Purpose |
 | --- | --- |
 | `FlutterPdfViewPlatform` | The interface an implementation extends; `buildView` returns the widget hosting the native view. |
-| `PdfViewPlatformController` | Drives one created view — page navigation, zoom, scroll, screenshot, unlock. |
+| `PdfViewPlatformController` | Drives one created view — page navigation, zoom, scroll, screenshot, unlock, **text search/selection**. |
 | `PdfViewCreationParams` | Document source plus initial settings, serialized for the native view factory. |
-| `PdfViewSettings` | The settings snapshot and the runtime diff (`updatesMap`) pushed on rebuild. |
-| `PdfViewCallbacks` | The viewer events an implementation reports back. |
-| `FitPolicy`, `PageAlignment`, `PdfColorMode`, `PDFPasswordFailure` | Shared value types, re-exported by `flutter_pdfview`. |
+| `PdfViewSettings` | The settings snapshot and the runtime diff (`updatesMap`) pushed on rebuild (includes `enableTextSelection` / `enableCopy`). |
+| `PdfViewCallbacks` | The viewer events an implementation reports back (includes `onTextSelectionChanged` / `onSearchResultChanged`). |
+| `FitPolicy`, `PageAlignment`, `PdfColorMode`, `PDFPasswordFailure`, `PdfTextMatch` | Shared value types, re-exported by `flutter_pdfview`. |
+| `kPdfTextLayerUnsupportedCode` | `PlatformException.code` implementations must use when they have no text layer. |
 | `MethodChannelFlutterPdfView` | The default implementation, backed by the `plugins.endigo.io/pdfview` platform view and per-view `plugins.endigo.io/pdfview_<id>` method channels. |
+
+## Text layer contract
+
+`PdfViewPlatformController` exposes:
+
+- `isTextLayerSupported()`
+- `searchText` / `nextMatch` / `previousMatch` / `setCurrentMatch` / `clearSearch`
+- `getSelectedText` / `clearSelection`
+
+**Rules for implementations:**
+
+1. If the platform has no text layer, `isTextLayerSupported()` returns `false`.
+2. Query methods (`searchText`, match navigation, `getSelectedText`) must **throw** with
+   `PlatformException(code: kPdfTextLayerUnsupportedCode)` (the method-channel controller turns
+   that into `UnsupportedError`). Do **not** return an empty list — that means “searched, found
+   nothing”.
+3. `clearSearch` / `clearSelection` may be no-ops when unsupported (clearing nothing is truthful).
+4. When supported, empty `searchText` results always mean “no matches”.
+
+See the app package README [Text layer](https://pub.dev/packages/flutter_pdfview#text-layer)
+section for the user-facing API and iOS/Android matrix.
 
 ## Implementing a platform
 
@@ -42,6 +64,8 @@ before it reaches an implementation, so implementations never observe `system`.
 
 Adding a new method with a default implementation, or a new optional parameter,
 is non-breaking. Removing or renaming anything, or adding a required parameter,
-is breaking and needs a major version bump.
+is breaking and needs a major version bump. Text-layer APIs were added in **1.1.0**
+as non-breaking for subclasses of `FlutterPdfViewPlatform`; custom controllers that
+*implement* (not extend) `PdfViewPlatformController` must implement the new members.
 
 [pub]: https://pub.dev/packages/flutter_pdfview

--- a/packages/flutter_pdfview_platform_interface/lib/src/method_channel/method_channel_pdf_view_controller.dart
+++ b/packages/flutter_pdfview_platform_interface/lib/src/method_channel/method_channel_pdf_view_controller.dart
@@ -84,6 +84,15 @@ class MethodChannelPdfViewController implements PdfViewPlatformController {
       case 'onTap':
         callbacks.onTap?.call();
         return null;
+      case 'onTextSelectionChanged':
+        callbacks.onTextSelectionChanged?.call(call.arguments['text'] as String?);
+        return null;
+      case 'onSearchResultChanged':
+        callbacks.onSearchResultChanged?.call(
+          (call.arguments['currentIndex'] as num?)?.toInt() ?? -1,
+          (call.arguments['total'] as num?)?.toInt() ?? 0,
+        );
+        return null;
     }
     throw MissingPluginException('${call.method} was invoked but has no handler');
   }
@@ -212,5 +221,66 @@ class MethodChannelPdfViewController implements PdfViewPlatformController {
   @override
   Future<void> updateSettings(Map<String, dynamic> updates) {
     return _channel.invokeMethod('updateSettings', updates);
+  }
+
+  @override
+  Future<bool> isTextLayerSupported() async {
+    return await _channel.invokeMethod<bool>('isTextLayerSupported') ?? false;
+  }
+
+  @override
+  Future<List<PdfTextMatch>> searchText(String query, {bool caseSensitive = false}) async {
+    final Object? raw = await _invokeTextMethod<Object?>('searchText', <String, dynamic>{
+      'query': query,
+      'caseSensitive': caseSensitive,
+    });
+    if (raw is! List) return const <PdfTextMatch>[];
+    return raw.whereType<Map<Object?, Object?>>().map(PdfTextMatch.fromMap).toList(growable: false);
+  }
+
+  @override
+  Future<PdfTextMatch?> nextMatch() => _activateMatch('nextMatch');
+
+  @override
+  Future<PdfTextMatch?> previousMatch() => _activateMatch('previousMatch');
+
+  @override
+  Future<PdfTextMatch?> setCurrentMatch(int index) =>
+      _activateMatch('setCurrentMatch', <String, dynamic>{'index': index});
+
+  @override
+  Future<String?> getSelectedText() => _invokeTextMethod<String?>('getSelectedText');
+
+  // clearSearch / clearSelection deliberately do not go through
+  // _invokeTextMethod: clearing nothing is a truthful outcome on a platform with
+  // no text layer, so they stay no-ops rather than throwing.
+  @override
+  Future<void> clearSearch() async {
+    await _channel.invokeMethod<void>('clearSearch');
+  }
+
+  @override
+  Future<void> clearSelection() async {
+    await _channel.invokeMethod<void>('clearSelection');
+  }
+
+  Future<PdfTextMatch?> _activateMatch(String method, [Map<String, dynamic>? arguments]) async {
+    final Object? raw = await _invokeTextMethod<Object?>(method, arguments);
+    return raw is Map<Object?, Object?> ? PdfTextMatch.fromMap(raw) : null;
+  }
+
+  /// Invokes a text-layer method, turning a platform that has no text layer into
+  /// an [UnsupportedError] instead of a value that reads as a real answer.
+  Future<T?> _invokeTextMethod<T>(String method, [Map<String, dynamic>? arguments]) async {
+    try {
+      return await _channel.invokeMethod<T>(method, arguments);
+    } on PlatformException catch (error) {
+      if (error.code == kPdfTextLayerUnsupportedCode) {
+        throw UnsupportedError(
+          error.message ?? 'The text layer is not supported on this platform.',
+        );
+      }
+      rethrow;
+    }
   }
 }

--- a/packages/flutter_pdfview_platform_interface/lib/src/pdf_view_callbacks.dart
+++ b/packages/flutter_pdfview_platform_interface/lib/src/pdf_view_callbacks.dart
@@ -18,6 +18,8 @@ class PdfViewCallbacks {
     this.onLoadComplete,
     this.onDraw,
     this.onTap,
+    this.onTextSelectionChanged,
+    this.onSearchResultChanged,
   });
 
   /// Invoked when the document has been rendered, with its page count.
@@ -47,4 +49,10 @@ class PdfViewCallbacks {
 
   /// Invoked when the user single-taps the view.
   final TapCallback? onTap;
+
+  /// Invoked when the user changes the text selection.
+  final TextSelectionChangedCallback? onTextSelectionChanged;
+
+  /// Invoked when the active search match changes.
+  final SearchResultChangedCallback? onSearchResultChanged;
 }

--- a/packages/flutter_pdfview_platform_interface/lib/src/pdf_view_platform_controller.dart
+++ b/packages/flutter_pdfview_platform_interface/lib/src/pdf_view_platform_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' show Offset, Size;
 
 import 'pdf_view_callbacks.dart';
+import 'types.dart';
 
 /// Drives a single PDF view that a platform implementation has created.
 ///
@@ -67,6 +68,47 @@ abstract class PdfViewPlatformController {
   /// The map uses the same key names that `PdfViewSettings.toMap` produces.
   /// Implementations may assume it is non-empty.
   Future<void> updateSettings(Map<String, dynamic> updates);
+
+  /// Whether this platform exposes a text layer at all.
+  ///
+  /// When `false`, every text method below throws [UnsupportedError] except
+  /// [clearSearch] and [clearSelection], which stay no-ops because "clear
+  /// nothing" is a truthful outcome.
+  Future<bool> isTextLayerSupported();
+
+  /// Searches the document for [query] and returns every match.
+  ///
+  /// The first match becomes the active one. An empty [query] clears the search
+  /// and returns an empty list.
+  ///
+  /// An empty result always means "searched, found nothing". Implementations
+  /// without a text layer must throw instead — see
+  /// [kPdfTextLayerUnsupportedCode].
+  Future<List<PdfTextMatch>> searchText(String query, {bool caseSensitive = false});
+
+  /// Activates the next match, wrapping at the end.
+  ///
+  /// Returns `null` when there is no active search session.
+  Future<PdfTextMatch?> nextMatch();
+
+  /// Activates the previous match, wrapping at the start.
+  ///
+  /// Returns `null` when there is no active search session.
+  Future<PdfTextMatch?> previousMatch();
+
+  /// Activates the match at [index] of the last [searchText] result.
+  ///
+  /// Returns `null` when [index] is out of range.
+  Future<PdfTextMatch?> setCurrentMatch(int index);
+
+  /// Clears search highlights and forgets the last [searchText] result.
+  Future<void> clearSearch();
+
+  /// Returns the selected text, or `null` when nothing is selected.
+  Future<String?> getSelectedText();
+
+  /// Clears the current text selection, if any.
+  Future<void> clearSelection();
 
   /// Replaces the callbacks this controller dispatches native events to.
   void updateCallbacks(PdfViewCallbacks callbacks);

--- a/packages/flutter_pdfview_platform_interface/lib/src/pdf_view_settings.dart
+++ b/packages/flutter_pdfview_platform_interface/lib/src/pdf_view_settings.dart
@@ -36,6 +36,8 @@ class PdfViewSettings {
     this.backgroundColor,
     this.maxZoom,
     this.minZoom,
+    this.enableTextSelection,
+    this.enableCopy,
   }) : assert(
          colorMode != PdfColorMode.system,
          'system must be resolved to light or dark before building settings',
@@ -109,6 +111,12 @@ class PdfViewSettings {
   /// Minimum zoom level.
   final double? minZoom;
 
+  /// Whether the user may select text in the native viewer.
+  final bool? enableTextSelection;
+
+  /// Whether the copy / share actions are offered for selected text.
+  final bool? enableCopy;
+
   /// Serializes every setting into the creation-parameter wire format.
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
@@ -134,6 +142,8 @@ class PdfViewSettings {
       'backgroundColor': backgroundColor?.toARGB32(),
       'maxZoom': maxZoom,
       'minZoom': minZoom,
+      'enableTextSelection': enableTextSelection,
+      'enableCopy': enableCopy,
     };
   }
 
@@ -179,6 +189,12 @@ class PdfViewSettings {
         updates['backgroundColor'] = bg.toARGB32();
       }
       // Present-with-null is omitted; natives keep the previous color.
+    }
+    if (enableTextSelection != newSettings.enableTextSelection) {
+      updates['enableTextSelection'] = newSettings.enableTextSelection;
+    }
+    if (enableCopy != newSettings.enableCopy) {
+      updates['enableCopy'] = newSettings.enableCopy;
     }
     return updates;
   }

--- a/packages/flutter_pdfview_platform_interface/lib/src/types.dart
+++ b/packages/flutter_pdfview_platform_interface/lib/src/types.dart
@@ -81,6 +81,79 @@ enum PageAlignment {
   top,
 }
 
+/// One occurrence of a search string inside a PDF document.
+///
+/// Returned by the text-search methods on [PdfViewPlatformController]. See
+/// [kPdfTextLayerUnsupportedCode] for how platforms without a text layer report
+/// that they cannot search at all — an empty match list always means "searched,
+/// found nothing", never "not supported here".
+class PdfTextMatch {
+  /// Creates a match description.
+  const PdfTextMatch({required this.pageIndex, required this.matchIndex, this.text});
+
+  /// Builds a match from its method-channel representation.
+  factory PdfTextMatch.fromMap(Map<Object?, Object?> map) {
+    return PdfTextMatch(
+      pageIndex: (map['pageIndex'] as num?)?.toInt() ?? 0,
+      matchIndex: (map['matchIndex'] as num?)?.toInt() ?? 0,
+      text: map['text'] as String?,
+    );
+  }
+
+  /// Zero-based page that contains this match.
+  final int pageIndex;
+
+  /// Zero-based index of this match in the full search result list.
+  final int matchIndex;
+
+  /// Matched string as reported by the platform, when available.
+  final String? text;
+
+  /// Serializes this match into its method-channel representation.
+  Map<String, Object?> toMap() => <String, Object?>{
+    'pageIndex': pageIndex,
+    'matchIndex': matchIndex,
+    'text': text,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfTextMatch &&
+      other.pageIndex == pageIndex &&
+      other.matchIndex == matchIndex &&
+      other.text == text;
+
+  @override
+  int get hashCode => Object.hash(pageIndex, matchIndex, text);
+
+  @override
+  String toString() => 'PdfTextMatch(pageIndex: $pageIndex, matchIndex: $matchIndex, text: $text)';
+}
+
+/// The `PlatformException.code` a platform implementation must use when it has
+/// no text layer at all.
+///
+/// Implementations must fail this way rather than returning an empty result:
+/// an empty list has to keep meaning "searched, found nothing", otherwise an app
+/// on a platform without text support silently reads as "this document contains
+/// no matches". [MethodChannelPdfViewController] translates this code into an
+/// [UnsupportedError].
+const String kPdfTextLayerUnsupportedCode = 'text_layer_unsupported';
+
+/// Signature for the callback that is invoked when the user changes the text
+/// selection in the PDF view.
+///
+/// [selectedText] is the selected string, or `null` when the selection is
+/// cleared.
+typedef TextSelectionChangedCallback = void Function(String? selectedText);
+
+/// Signature for the callback that is invoked when the active search match
+/// changes.
+///
+/// [currentIndex] is the zero-based index of the active match, or `-1` when
+/// there is no active match. [total] is the number of matches.
+typedef SearchResultChangedCallback = void Function(int currentIndex, int total);
+
 /// Color theme for PDF page content and the gutter behind it.
 ///
 /// - [light]: normal rendering (no inversion).

--- a/packages/flutter_pdfview_platform_interface/pubspec.yaml
+++ b/packages/flutter_pdfview_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_pdfview_platform_interface
 description: A common platform interface for the flutter_pdfview plugin.
-version: 1.0.1
+version: 1.1.0
 homepage: https://github.com/endigo/flutter_pdfview
 repository: https://github.com/endigo/flutter_pdfview
 issue_tracker: https://github.com/endigo/flutter_pdfview/issues

--- a/packages/flutter_pdfview_platform_interface/test/pdf_view_settings_test.dart
+++ b/packages/flutter_pdfview_platform_interface/test/pdf_view_settings_test.dart
@@ -28,6 +28,8 @@ void main() {
         backgroundColor: const Color(0xFF102030),
         maxZoom: 4,
         minZoom: 1,
+        enableTextSelection: false,
+        enableCopy: false,
       );
 
       expect(settings.toMap(), <String, dynamic>{
@@ -52,6 +54,8 @@ void main() {
         'backgroundColor': 0xFF102030,
         'maxZoom': 4.0,
         'minZoom': 1.0,
+        'enableTextSelection': false,
+        'enableCopy': false,
       });
     });
 

--- a/packages/flutter_pdfview_platform_interface/test/text_layer_test.dart
+++ b/packages/flutter_pdfview_platform_interface/test/text_layer_test.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_pdfview_platform_interface/flutter_pdfview_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const int _viewId = 11;
+final MethodChannel _channel = MethodChannel('plugins.endigo.io/pdfview_$_viewId');
+
+/// The payload a platform with a text layer returns for one match.
+Map<Object?, Object?> _match(int page, int index, String? text) => <Object?, Object?>{
+  'pageIndex': page,
+  'matchIndex': index,
+  'text': text,
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MethodChannelPdfViewController controller;
+  final List<MethodCall> log = <MethodCall>[];
+
+  void mockPlatform(Future<Object?>? Function(MethodCall call) handler) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      _channel,
+      (MethodCall call) async {
+        log.add(call);
+        return handler(call);
+      },
+    );
+  }
+
+  /// Answers every text method the way a platform with no text layer must.
+  void mockPlatformWithoutTextLayer() {
+    mockPlatform((MethodCall call) async {
+      if (call.method == 'isTextLayerSupported') return false;
+      if (call.method == 'clearSearch' || call.method == 'clearSelection') return null;
+      throw PlatformException(code: kPdfTextLayerUnsupportedCode, message: 'no text layer here');
+    });
+  }
+
+  setUp(() {
+    log.clear();
+    controller = MethodChannelPdfViewController(_viewId, const PdfViewCallbacks());
+  });
+
+  tearDown(() {
+    controller.dispose();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      _channel,
+      null,
+    );
+  });
+
+  group('search', () {
+    test('decodes matches in order', () async {
+      mockPlatform((_) async => <Object?>[_match(0, 0, 'lorem'), _match(3, 1, 'lorem')]);
+
+      final List<PdfTextMatch> matches = await controller.searchText('lorem');
+
+      expect(matches, <PdfTextMatch>[
+        const PdfTextMatch(pageIndex: 0, matchIndex: 0, text: 'lorem'),
+        const PdfTextMatch(pageIndex: 3, matchIndex: 1, text: 'lorem'),
+      ]);
+      expect(log.single.arguments, <String, dynamic>{'query': 'lorem', 'caseSensitive': false});
+    });
+
+    test('forwards caseSensitive', () async {
+      mockPlatform((_) async => <Object?>[]);
+      await controller.searchText('Lorem', caseSensitive: true);
+      expect(log.single.arguments['caseSensitive'], isTrue);
+    });
+
+    test('an empty result means searched-and-found-nothing, not unsupported', () async {
+      mockPlatform((_) async => <Object?>[]);
+      expect(await controller.searchText('nope'), isEmpty);
+    });
+
+    test('skips entries that are not maps', () async {
+      mockPlatform((_) async => <Object?>['garbage', _match(1, 0, 'ok')]);
+      expect(await controller.searchText('ok'), <PdfTextMatch>[
+        const PdfTextMatch(pageIndex: 1, matchIndex: 0, text: 'ok'),
+      ]);
+    });
+
+    test('nextMatch / previousMatch decode the activated match', () async {
+      mockPlatform((_) async => _match(2, 1, 'hit'));
+      expect(
+        await controller.nextMatch(),
+        const PdfTextMatch(pageIndex: 2, matchIndex: 1, text: 'hit'),
+      );
+      expect(await controller.previousMatch(), isNotNull);
+    });
+
+    test('nextMatch returns null when there is no session', () async {
+      mockPlatform((_) async => null);
+      expect(await controller.nextMatch(), isNull);
+    });
+
+    test('setCurrentMatch passes the index', () async {
+      mockPlatform((_) async => _match(0, 4, 'x'));
+      await controller.setCurrentMatch(4);
+      expect(log.single.arguments, <String, dynamic>{'index': 4});
+    });
+  });
+
+  group('selection', () {
+    test('getSelectedText returns the platform string', () async {
+      mockPlatform((_) async => 'selected words');
+      expect(await controller.getSelectedText(), 'selected words');
+    });
+
+    test('getSelectedText returns null when nothing is selected', () async {
+      mockPlatform((_) async => null);
+      expect(await controller.getSelectedText(), isNull);
+    });
+  });
+
+  group('callbacks', () {
+    Future<void> emit(String method, dynamic arguments) {
+      return TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            _channel.name,
+            const StandardMethodCodec().encodeMethodCall(MethodCall(method, arguments)),
+            (_) {},
+          );
+    }
+
+    test('onTextSelectionChanged reports the text and the cleared state', () async {
+      final List<String?> seen = <String?>[];
+      controller.updateCallbacks(
+        PdfViewCallbacks(onTextSelectionChanged: (String? text) => seen.add(text)),
+      );
+
+      await emit('onTextSelectionChanged', <String, dynamic>{'text': 'hello'});
+      await emit('onTextSelectionChanged', <String, dynamic>{'text': null});
+
+      expect(seen, <String?>['hello', null]);
+    });
+
+    test('onSearchResultChanged reports index and total', () async {
+      int? index;
+      int? total;
+      controller.updateCallbacks(
+        PdfViewCallbacks(
+          onSearchResultChanged: (int i, int t) {
+            index = i;
+            total = t;
+          },
+        ),
+      );
+
+      await emit('onSearchResultChanged', <String, dynamic>{'currentIndex': 2, 'total': 7});
+      expect(index, 2);
+      expect(total, 7);
+
+      await emit('onSearchResultChanged', <String, dynamic>{'currentIndex': -1, 'total': 0});
+      expect(index, -1);
+      expect(total, 0);
+    });
+  });
+
+  group('platform without a text layer', () {
+    setUp(mockPlatformWithoutTextLayer);
+
+    test('isTextLayerSupported reports false', () async {
+      expect(await controller.isTextLayerSupported(), isFalse);
+    });
+
+    test('searchText throws instead of returning an empty list', () async {
+      // The whole point: "no matches" must never be confusable with
+      // "this platform cannot search".
+      await expectLater(controller.searchText('lorem'), throwsUnsupportedError);
+    });
+
+    test('getSelectedText throws instead of returning null', () async {
+      await expectLater(controller.getSelectedText(), throwsUnsupportedError);
+    });
+
+    test('match navigation throws', () async {
+      await expectLater(controller.nextMatch(), throwsUnsupportedError);
+      await expectLater(controller.previousMatch(), throwsUnsupportedError);
+      await expectLater(controller.setCurrentMatch(0), throwsUnsupportedError);
+    });
+
+    test('clearSearch and clearSelection stay no-ops', () async {
+      // Clearing nothing is a truthful outcome, so these must not throw.
+      await expectLater(controller.clearSearch(), completes);
+      await expectLater(controller.clearSelection(), completes);
+    });
+  });
+
+  test('an unrelated PlatformException is not turned into UnsupportedError', () async {
+    mockPlatform((_) async => throw PlatformException(code: 'boom'));
+    await expectLater(controller.searchText('x'), throwsA(isA<PlatformException>()));
+  });
+
+  group('PdfTextMatch', () {
+    test('round-trips through its map form', () {
+      const PdfTextMatch match = PdfTextMatch(pageIndex: 4, matchIndex: 9, text: 'hit');
+      expect(PdfTextMatch.fromMap(match.toMap()), match);
+    });
+
+    test('defaults missing numbers to zero and tolerates a null text', () {
+      final PdfTextMatch match = PdfTextMatch.fromMap(<Object?, Object?>{});
+      expect(match.pageIndex, 0);
+      expect(match.matchIndex, 0);
+      expect(match.text, isNull);
+    });
+
+    test('equality and hashCode consider every field', () {
+      const PdfTextMatch a = PdfTextMatch(pageIndex: 1, matchIndex: 2, text: 'x');
+      expect(a, const PdfTextMatch(pageIndex: 1, matchIndex: 2, text: 'x'));
+      expect(a.hashCode, const PdfTextMatch(pageIndex: 1, matchIndex: 2, text: 'x').hashCode);
+      expect(a, isNot(const PdfTextMatch(pageIndex: 1, matchIndex: 2, text: 'y')));
+      expect(a, isNot(const PdfTextMatch(pageIndex: 9, matchIndex: 2, text: 'x')));
+    });
+  });
+
+  group('settings', () {
+    test('text-interaction flags are in the creation wire format', () {
+      final Map<String, dynamic> map = PdfViewSettings(
+        enableTextSelection: false,
+        enableCopy: false,
+      ).toMap();
+      expect(map['enableTextSelection'], isFalse);
+      expect(map['enableCopy'], isFalse);
+    });
+
+    test('changing them is pushed as a runtime update', () {
+      final PdfViewSettings before = PdfViewSettings(enableTextSelection: true, enableCopy: true);
+      final PdfViewSettings after = PdfViewSettings(enableTextSelection: false, enableCopy: false);
+      expect(before.updatesMap(after), <String, dynamic>{
+        'enableTextSelection': false,
+        'enableCopy': false,
+      });
+    });
+
+    test('leaving them alone produces no update', () {
+      final PdfViewSettings before = PdfViewSettings(enableTextSelection: true, enableCopy: true);
+      final PdfViewSettings after = PdfViewSettings(enableTextSelection: true, enableCopy: true);
+      expect(before.updatesMap(after), isEmpty);
+    });
+  });
+}

--- a/scripts/make_text_pdf.py
+++ b/scripts/make_text_pdf.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Generate the text-layer PDF fixture used by the text integration tests.
+
+The tests need a document whose text content is known exactly, so that a search
+can assert both the number of matches and the page each one lands on. No PDF
+tool is assumed to be installed, so a minimal PDF 1.4 file is written directly
+here with uncompressed content streams and one of the standard 14 fonts.
+
+Layout (see WORDS below):
+
+    page 0: "Alpha searchable Beta"   -> 1 match for "searchable"
+    page 1: "Gamma Delta"             -> 0 matches
+    page 2: "searchable Epsilon"      -> 1 match
+            "searchable again"        -> 1 match
+
+So "searchable" has 3 matches, on pages 0, 2 and 2, and "Gamma" has exactly one
+on page 1. "SEARCHABLE" in caps appears nowhere, which is what makes the
+case-sensitivity assertion meaningful.
+
+Usage: python3 scripts/make_text_pdf.py [output.pdf]
+"""
+
+import sys
+from pathlib import Path
+
+# Each entry is one page: a list of text lines drawn top-down.
+WORDS = [
+    ["Alpha searchable Beta"],
+    ["Gamma Delta"],
+    ["searchable Epsilon", "searchable again"],
+]
+
+
+def escape(text: str) -> str:
+    """Escapes a string for a PDF literal string object."""
+    return text.replace("\\", r"\\").replace("(", r"\(").replace(")", r"\)")
+
+
+def content_stream(lines: list[str]) -> bytes:
+    """Builds an uncompressed content stream drawing `lines` at 24pt."""
+    out = ["BT", "/F1 24 Tf", "72 720 Td", "28 TL"]
+    for index, line in enumerate(lines):
+        if index:
+            out.append("T*")
+        out.append(f"({escape(line)}) Tj")
+    out.append("ET")
+    return "\n".join(out).encode("ascii")
+
+
+def build_pdf() -> bytes:
+    # Object 1 = catalog, 2 = pages, 3 = font, then per page: page + contents.
+    page_count = len(WORDS)
+    first_page_obj = 4
+    kids = " ".join(f"{first_page_obj + i * 2} 0 R" for i in range(page_count))
+
+    objects: list[bytes] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        f"<< /Type /Pages /Kids [{kids}] /Count {page_count} >>".encode("ascii"),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    for index, lines in enumerate(WORDS):
+        contents_obj = first_page_obj + index * 2 + 1
+        objects.append(
+            (
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+                "/Resources << /Font << /F1 3 0 R >> >> "
+                f"/Contents {contents_obj} 0 R >>"
+            ).encode("ascii")
+        )
+        stream = content_stream(lines)
+        objects.append(
+            b"<< /Length " + str(len(stream)).encode("ascii") + b" >>\nstream\n"
+            + stream
+            + b"\nendstream"
+        )
+
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{number} 0 obj\n".encode("ascii") + body + b"\nendobj\n"
+
+    xref_offset = len(out)
+    out += f"xref\n0 {len(objects) + 1}\n".encode("ascii")
+    out += b"0000000000 65535 f \n"
+    for offset in offsets[1:]:
+        out += f"{offset:010d} 00000 n \n".encode("ascii")
+    out += (
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n"
+    ).encode("ascii")
+    return bytes(out)
+
+
+def main() -> None:
+    destination = Path(
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else Path(__file__).resolve().parent.parent
+        / "packages/flutter_pdfview/example/assets/demo-text.pdf"
+    )
+    destination.write_bytes(build_pdf())
+    print(f"wrote {destination} ({destination.stat().st_size} bytes)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the **text layer** on top of the federated 1.5.0 stack (`migrate/kotlin-swift` / #345):

- Find-in-document ([#137](https://github.com/endigo/flutter_pdfview/issues/137))
- Text selection ([#285](https://github.com/endigo/flutter_pdfview/issues/285))
- Control over copy ([#108](https://github.com/endigo/flutter_pdfview/issues/108))

**Versions (not published yet — publish interface first):**
- `flutter_pdfview_platform_interface` **1.1.0**
- `flutter_pdfview` **1.5.0-beta.13**

```yaml
dependencies:
  flutter_pdfview: 1.5.0-beta.13
```

## API

**Controller**
- `isTextLayerSupported()`
- `searchText(query, {caseSensitive})` → `List<PdfTextMatch>`
- `nextMatch` / `previousMatch` / `setCurrentMatch` / `clearSearch`
- `getSelectedText` / `clearSelection`

**Widget**
- `enableTextSelection` / `enableCopy` (default `true`, live update without remount)
- `onTextSelectionChanged` / `onSearchResultChanged`

## Platform support

| Capability | iOS (PDFKit) | Android |
|------------|:------------:|:-------:|
| Search + highlights | ✅ | ❌ throws `UnsupportedError` |
| Selection | ✅ | ❌ |
| Suppress copy menu | ✅ | ❌ |
| `isTextLayerSupported` | `true` | `false` |

Android has no text layer today: AndroidPdfViewer's `PdfiumCore` does not bind Pdfium's `FPDFText_*` API in Java (even though `libpdfium` exports the symbols). Returning empty results would look like “no matches”, so query methods throw and apps should branch on `isTextLayerSupported()`. A future JNI shim can implement the same interface without Dart API changes.

## Base

Rebased onto `migrate/kotlin-swift` (includes beta.12: `spacing` + `setPage(withAnimation:)`). Text-layer changelog is **beta.13** so it does not collide with the already-published beta.12.

## Test plan

- [x] `flutter analyze` clean (both packages)
- [x] Dart unit tests (interface + app package, including text_layer tests)
- [x] Android unit tests (`FlutterPDFViewTextLayerTest` + full suite)
- [ ] `example/integration_test/text_layer_test.dart` on iOS simulator (real PDFKit)
- [ ] Manual: search, next/prev match, selection, `enableCopy: false`
- [ ] Publish interface **1.1.0**, then app **1.5.0-beta.13**

## Related

- Parent stack: #345
- Issues: #137 #285 #108